### PR TITLE
feat: add reviewer generators and English skill assets

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,253 +1,264 @@
-# 同事.skill 安装说明
+# colleague.skill Installation Guide
 
 ---
 
-## 选择你的平台
+## Choose Your Platform
 
-### A. Claude Code（推荐）
+### A. Claude Code (recommended)
 
-本项目遵循官方 [AgentSkills](https://agentskills.io) 标准，整个 repo 就是 skill 目录。克隆到 Claude skills 目录即可：
+This project follows the official [AgentSkills](https://agentskills.io) standard. The entire repository is the skill directory, so you only need to clone it into Claude's skills path:
 
 ```bash
-# ⚠️ 必须在 git 仓库根目录执行！
-cd $(git rev-parse --show-toplevel)
+# Must be run at the git repository root
+cd "$(git rev-parse --show-toplevel)"
 
-# 方式 1：安装到当前项目
+# Option 1: install into the current project
 mkdir -p .claude/skills
 git clone https://github.com/titanwings/colleague-skill .claude/skills/create-colleague
 
-# 方式 2：安装到全局（所有项目都能用）
+# Option 2: install globally for all projects
 git clone https://github.com/titanwings/colleague-skill ~/.claude/skills/create-colleague
 ```
 
-然后在 Claude Code 中说 `/create-colleague` 即可启动。
+Then invoke `/create-colleague` inside Claude Code.
 
-生成的同事 Skill 默认写入 `./colleagues/` 目录。
+Generated colleague skills are written to `./colleagues/` by default.
 
 ---
 
 ### B. OpenClaw
 
 ```bash
-# 克隆到 OpenClaw 的 skills 目录
 git clone https://github.com/titanwings/colleague-skill ~/.openclaw/workspace/skills/create-colleague
 ```
 
-重启 OpenClaw session，说 `/create-colleague` 启动。
+Restart the OpenClaw session, then run `/create-colleague`.
 
 ---
 
-## 依赖安装
+## Install Dependencies
 
 ```bash
-# 基础（Python 3.9+）
-pip3 install pypinyin        # 中文姓名转拼音 slug（可选但推荐）
+# Base requirements (Python 3.9+)
+pip3 install pypinyin        # Optional but recommended for Chinese-name slug generation
 
-# 飞书浏览器方案（内部文档/需要登录权限的文档）
+# Feishu browser method (for internal docs / docs requiring login)
 pip3 install playwright
-playwright install chromium  # 仅需安装 chromium，不需要完整 Chrome
+playwright install chromium  # Chromium is enough; full Chrome is not required
 
-# 飞书 MCP 方案（公司授权文档，通过 App Token 读取）
-npm install -g feishu-mcp    # 需要 Node.js 16+
+# Feishu MCP method (for app-authorized document access)
+npm install -g feishu-mcp    # Requires Node.js 16+
 
-# 其他格式支持（可选）
-pip3 install python-docx     # Word .docx 转文本
-pip3 install openpyxl        # Excel .xlsx 转 CSV
+# Optional format support
+pip3 install python-docx     # Convert Word .docx to text
+pip3 install openpyxl        # Convert Excel .xlsx to CSV
 ```
 
-### 平台方案选择指南
+### Which collector should you use?
 
-| 场景 | 推荐方案 |
-|------|---------|
-| 飞书用户，有 App 权限 | `feishu_auto_collector.py` |
-| 飞书内部文档（无 App 权限）| `feishu_browser.py` |
-| 飞书手动指定链接 | `feishu_mcp_client.py` |
-| 钉钉用户 | `dingtalk_auto_collector.py` |
-| 钉钉消息采集失败 | 手动截图 → 上传图片 |
-| Slack 用户 | `slack_auto_collector.py` |
+| Scenario | Recommended Tool |
+|----------|------------------|
+| Feishu user with app permissions | `feishu_auto_collector.py` |
+| Feishu internal doc without app permissions | `feishu_browser.py` |
+| Manually provided Feishu link | `feishu_mcp_client.py` |
+| DingTalk user | `dingtalk_auto_collector.py` |
+| DingTalk message collection fails | upload screenshots manually |
+| Slack user | `slack_auto_collector.py` |
 
-**飞书自动采集初始化**：
+**Initialize Feishu auto-collection**
+
 ```bash
 python3 tools/feishu_auto_collector.py --setup
-# 输入飞书开放平台的 App ID 和 App Secret
+# Enter the App ID and App Secret from Feishu Open Platform
 ```
 
-**钉钉自动采集初始化**：
+**Initialize DingTalk auto-collection**
+
 ```bash
 python3 tools/dingtalk_auto_collector.py --setup
-# 输入钉钉开放平台的 AppKey 和 AppSecret
-# 首次运行加 --show-browser 参数以完成钉钉登录
+# Enter the AppKey and AppSecret from DingTalk Open Platform
+# Add --show-browser on first run to complete the DingTalk login flow
 ```
 
-**飞书 MCP 初始化**（手动指定链接时使用）：
+**Initialize Feishu MCP** (used for manually provided links)
+
 ```bash
 python3 tools/feishu_mcp_client.py --setup
 ```
 
-**飞书浏览器方案**（首次使用会弹窗登录，之后自动复用登录态）：
+**Use the Feishu browser method** (first run opens a login window, later runs reuse the session)
+
 ```bash
 python3 tools/feishu_browser.py \
   --url "https://xxx.feishu.cn/wiki/xxx" \
-  --show-browser    # 首次使用加这个参数，登录后不再需要
+  --show-browser
 ```
 
-**Slack 自动采集初始化**：
+**Initialize Slack auto-collection**
+
 ```bash
 pip3 install slack-sdk
 python3 tools/slack_auto_collector.py --setup
-# 按提示输入 Bot User OAuth Token（xoxb-...）
+# Paste the Bot User OAuth Token (xoxb-...)
 ```
 
-> Slack 详细配置见下方「[Slack 自动采集配置](#slack-自动采集配置)」章节
+See the [Slack Auto-Collection Setup](#slack-auto-collection-setup) section below for detailed Slack steps.
 
 ---
 
-## Slack 自动采集配置
+## Slack Auto-Collection Setup
 
-### 前置条件
+### Prerequisites
 
 - Python 3.9+
-- Slack Workspace（需要**管理员权限**安装 App，或联系管理员帮你安装）
+- A Slack workspace
+- Admin permission to install the app, or access to someone who can install it
 - `pip3 install slack-sdk`
 
-> **免费版 Workspace 限制**：只能访问最近 **90 天**的消息记录。付费版（Pro / Business+ / Enterprise）无此限制。
+> On free Slack workspaces, only the most recent 90 days of messages are available. Paid plans do not have this limit.
 
 ---
 
-### 步骤 1：创建 Slack App
+### Step 1: Create a Slack app
 
-1. 前往 [https://api.slack.com/apps](https://api.slack.com/apps) → **Create New App**
-2. 选择 **From scratch**
-3. 填写 App Name（如 `colleague-skill-bot`），选择目标 Workspace → **Create App**
-
----
-
-### 步骤 2：配置 Bot Token Scopes
-
-进入 **OAuth & Permissions** → **Bot Token Scopes** → **Add an OAuth Scope**，添加以下权限：
-
-| Scope | 用途 |
-|-------|------|
-| `users:read` | 搜索用户列表（必需） |
-| `channels:read` | 列出 public channels（必需） |
-| `channels:history` | 读取 public channel 历史消息（必需） |
-| `groups:read` | 列出 private channels（必需） |
-| `groups:history` | 读取 private channel 历史消息（必需） |
-| `mpim:read` | 列出群 DM（可选） |
-| `mpim:history` | 读取群 DM 历史消息（可选） |
-| `im:read` | 列出 DM（可选，需用户授权） |
-| `im:history` | 读取 DM 历史消息（可选，需用户授权） |
+1. Go to `https://api.slack.com/apps`
+2. Click **Create New App**
+3. Choose **From scratch**
+4. Give the app a name such as `colleague-skill-bot`
+5. Select the target workspace and create the app
 
 ---
 
-### 步骤 3：安装 App 到 Workspace
+### Step 2: Configure Bot Token Scopes
 
-1. 仍在 **OAuth & Permissions** 页面，点击 **Install to Workspace**
-2. Workspace 管理员审批后，复制 **Bot User OAuth Token**（格式：`xoxb-...`）
+In **OAuth & Permissions** -> **Bot Token Scopes**, add:
+
+| Scope | Purpose |
+|-------|---------|
+| `users:read` | Search for users |
+| `channels:read` | List public channels |
+| `channels:history` | Read public-channel history |
+| `groups:read` | List private channels |
+| `groups:history` | Read private-channel history |
+| `mpim:read` | List group DMs |
+| `mpim:history` | Read group-DM history |
+| `im:read` | List DMs (optional, requires user authorization) |
+| `im:history` | Read DM history (optional, requires user authorization) |
 
 ---
 
-### 步骤 4：将 Bot 加入目标频道
+### Step 3: Install the app into the workspace
 
-Bot 只能读取**它已加入**的频道。在 Slack 中，进入每个目标频道，输入：
+1. Stay on **OAuth & Permissions**
+2. Click **Install to Workspace**
+3. After approval, copy the **Bot User OAuth Token** (`xoxb-...`)
 
-```
+---
+
+### Step 4: Invite the bot into target channels
+
+The bot can only read channels it has joined. In each target channel, run:
+
+```text
 /invite @your-bot-name
 ```
 
-> 提示：如果你不知道目标同事在哪些频道，可以先不邀请，运行采集时脚本会告知 Bot 加入了哪些频道，再补充邀请。
+If you do not yet know which channels the person is in, you can skip this first. The collector will tell you which channels it can see, and you can invite the bot afterward.
 
 ---
 
-### 步骤 5：运行配置向导
+### Step 5: Run the setup wizard
 
 ```bash
 python3 tools/slack_auto_collector.py --setup
 ```
 
-按提示粘贴 Bot Token，脚本会自动验证并保存到 `~/.colleague-skill/slack_config.json`。
+Paste the bot token when prompted. It will be validated automatically and stored in `~/.colleague-skill/slack_config.json`.
 
-配置成功后你会看到：
-```
-验证 Token ... OK
-  Workspace：Your Company，Bot：colleague-skill-bot
+Successful setup looks like this:
 
-✅ 配置已保存到 /Users/you/.colleague-skill/slack_config.json
+```text
+Validating token ... OK
+  Workspace: Your Company, Bot: colleague-skill-bot
+
+Configuration saved to /Users/you/.colleague-skill/slack_config.json
 ```
 
 ---
 
-### 步骤 6：采集同事数据
+### Step 6: Collect colleague data
 
 ```bash
-# 基本用法（输入同事的中文名或英文用户名）
-python3 tools/slack_auto_collector.py --name "张三"
+# Basic usage
 python3 tools/slack_auto_collector.py --name "john.doe"
 
-# 指定输出目录
-python3 tools/slack_auto_collector.py --name "张三" --output-dir ./knowledge/zhangsan
+# Custom output directory
+python3 tools/slack_auto_collector.py --name "john.doe" --output-dir ./knowledge/john-doe
 
-# 限制采集量（大 Workspace 建议先小量测试）
-python3 tools/slack_auto_collector.py --name "张三" --msg-limit 500 --channel-limit 20
+# Limit collection size for a large workspace
+python3 tools/slack_auto_collector.py --name "john.doe" --msg-limit 500 --channel-limit 20
 ```
 
-输出文件：
-```
-knowledge/张三/
-├── messages.txt            # 按权重分类的消息记录
-└── collection_summary.json # 采集摘要（用户信息、频道列表、时间）
+Output files:
+
+```text
+knowledge/john-doe/
+├── messages.txt
+└── collection_summary.json
 ```
 
 ---
 
-### 常见报错与解决
+### Common errors
 
-| 报错 | 原因 | 解决 |
-|------|------|------|
-| `missing_scope: channels:history` | Bot Token 缺少权限 | 回到 api.slack.com → OAuth & Permissions 添加对应 Scope，重新安装 App |
-| `invalid_auth` | Token 无效或已吊销 | 重新运行 `--setup` 配置新 Token |
-| `not_in_channel` | Bot 未加入该频道 | 在 Slack 里 `/invite @bot` 邀请 Bot |
-| 未找到用户 | 姓名拼写不对 | 改用英文用户名（如 `john.doe`）或 Slack display name |
-| 消息只有 90 天 | 免费版限制 | 升级 Workspace 或手动补充截图 |
-| 速率限制（429）| 请求太频繁 | 脚本会自动等待重试，无需手动处理 |
+| Error | Cause | Fix |
+|------|------|-----|
+| `missing_scope: channels:history` | Bot token is missing a required scope | Add the scope in Slack and reinstall the app |
+| `invalid_auth` | Token is invalid or revoked | Run `--setup` again with a fresh token |
+| `not_in_channel` | Bot was not invited into the channel | Run `/invite @bot` in Slack |
+| User not found | Name is misspelled or does not match Slack | Try the Slack username, such as `john.doe` |
+| Only 90 days of messages | Free plan limitation | Upgrade the workspace or add screenshots manually |
+| Rate limited (429) | Too many requests | The script automatically waits and retries |
 
-## 快速验证
+---
+
+## Quick Verification
 
 ```bash
-cd ~/.claude/skills/create-colleague   # 或你的项目 .claude/skills/create-colleague
+cd ~/.claude/skills/create-colleague
 
-# 测试飞书解析器
+# Test the Feishu parser
 python3 tools/feishu_parser.py --help
 
-# 测试 Slack 采集器
+# Test the Slack collector
 python3 tools/slack_auto_collector.py --help
 
-# 测试邮件解析器
+# Test the email parser
 python3 tools/email_parser.py --help
 
-# 列出已有同事 Skill
+# List existing colleague skills
 python3 tools/skill_writer.py --action list --base-dir ./colleagues
 ```
 
 ---
 
-## 目录结构说明
+## Directory Layout
 
-本项目整个 repo 就是一个 skill 目录（AgentSkills 标准格式）：
+The entire repository is a single skill directory in AgentSkills format:
 
-```
-colleague-skill/        ← clone 到 .claude/skills/create-colleague/
-├── SKILL.md            # skill 入口（官方 frontmatter）
-├── prompts/            # 分析和生成的 Prompt 模板
-├── tools/              # Python 工具脚本
-├── docs/               # 文档（PRD 等）
+```text
+colleague-skill/        # clone into .claude/skills/create-colleague/
+├── SKILL.md            # skill entry point
+├── prompts/            # analysis and generation prompt templates
+├── tools/              # Python utilities
+├── docs/               # documentation (PRD, roadmap, etc.)
 │
-└── colleagues/         # 生成的同事 Skill 存放处（.gitignore 排除）
+└── colleagues/         # generated colleague skills (.gitignored)
     └── {slug}/
-        ├── SKILL.md            # 完整 Skill（Persona + Work）
-        ├── work.md             # 仅工作能力
-        ├── persona.md          # 仅人物性格
-        ├── meta.json           # 元数据
-        ├── versions/           # 历史版本
-        └── knowledge/          # 原始材料归档
+        ├── SKILL.md
+        ├── work.md
+        ├── persona.md
+        ├── meta.json
+        ├── versions/
+        └── knowledge/
 ```

--- a/README.md
+++ b/README.md
@@ -138,6 +138,21 @@ Once created, invoke the colleague Skill with `/{slug}`.
 | `/colleague-rollback {slug} {version}` | Rollback to a previous version |
 | `/delete-colleague {slug}` | Delete |
 
+### Reviewer Commands
+
+| Command | Description |
+|---------|-------------|
+| `/create-pr-reviewer` | Create a review-only clone for PR/code review |
+| `/create-design-reviewer` | Create a review-only clone for RFC/design/architecture review |
+| `/list-pr-reviewers` | List generated PR reviewers |
+| `/list-design-reviewers` | List generated design reviewers |
+| `/reviewer-rollback pr {slug} {version}` | Roll back a PR reviewer |
+| `/reviewer-rollback design {slug} {version}` | Roll back a design reviewer |
+| `/delete-pr-reviewer {slug}` | Delete a PR reviewer |
+| `/delete-design-reviewer {slug}` | Delete a design reviewer |
+
+Reviewer clones are review-only. They emulate how a colleague evaluates code or design material, but they do not replace the full colleague Skill or act as a general worker/persona clone.
+
 ---
 
 ## Demo

--- a/SKILL.md
+++ b/SKILL.md
@@ -29,6 +29,19 @@ allowed-tools: Read, Write, Edit, Bash
 
 当用户说 `/list-colleagues` 时列出所有已生成的同事。
 
+当用户说以下任意内容时，进入 PR 审查者创建流程：
+- `/create-pr-reviewer`
+- "帮我创建一个 PR 审查者"
+- "克隆这个同事的代码 review 风格"
+
+当用户说以下任意内容时，进入设计审查者创建流程：
+- `/create-design-reviewer`
+- "帮我创建一个设计审查者"
+- "克隆这个同事的架构评审风格"
+
+当用户说 `/list-pr-reviewers` 时列出所有 PR 审查者。
+当用户说 `/list-design-reviewers` 时列出所有设计审查者。
+
 ---
 
 ## 工具使用规则
@@ -52,6 +65,7 @@ allowed-tools: Read, Write, Edit, Bash
 
 **基础目录**：Skill 文件写入 `./colleagues/{slug}/`（相对于本项目目录）。
 如需改为全局路径，用 `--base-dir ~/.openclaw/workspace/skills/colleagues`。
+PR 审查者写入 `./reviewers/pr/{slug}/`，设计审查者写入 `./reviewers/design/{slug}/`。
 
 ---
 
@@ -476,6 +490,54 @@ user-invocable: true
 
 ---
 
+## 主流程：创建 PR 审查者 Skill
+
+PR 审查者是**仅用于评审**的克隆。它只模拟这个人如何看 diff、定严重级别、提阻塞意见，不替代完整同事 Skill，也不作为通用 worker/persona clone。
+
+1. 参考 `${CLAUDE_SKILL_DIR}/prompts/review_pr_intake.md` 收集最少必要信息
+2. 导入与代码评审相关的材料：PR 评论、review 线程、技术讨论、事故复盘评论
+3. 参考 `${CLAUDE_SKILL_DIR}/prompts/review_pr_analyzer.md` 提炼严重级别、阻塞标准、常见问题类型、审批阈值和措辞风格
+4. 参考 `${CLAUDE_SKILL_DIR}/prompts/review_pr_builder.md` 生成 `/tmp/{slug}_review.md`
+5. 参考 `${CLAUDE_SKILL_DIR}/prompts/review_pr_examples_builder.md` 生成 `/tmp/{slug}_examples.md`
+6. 用以下命令写入单独目录：
+
+```bash
+python3 ${CLAUDE_SKILL_DIR}/tools/skill_writer.py \
+  --action create-reviewer \
+  --reviewer-type pr \
+  --slug {slug} \
+  --meta /tmp/{slug}_meta.json \
+  --review /tmp/{slug}_review.md \
+  --examples /tmp/{slug}_examples.md \
+  --base-dir ./reviewers/pr
+```
+
+---
+
+## 主流程：创建设计审查者 Skill
+
+设计审查者也是**仅用于评审**的克隆。它只模拟这个人如何看 RFC、设计文档和架构权衡，不替代完整同事 Skill，也不作为通用 worker/persona clone。
+
+1. 参考 `${CLAUDE_SKILL_DIR}/prompts/review_design_intake.md` 收集最少必要信息
+2. 导入与设计评审相关的材料：RFC 评论、设计文档、API review、规划讨论
+3. 参考 `${CLAUDE_SKILL_DIR}/prompts/review_design_analyzer.md` 提炼评估标准、常见追问、红旗信号、发布与可观测性要求
+4. 参考 `${CLAUDE_SKILL_DIR}/prompts/review_design_builder.md` 生成 `/tmp/{slug}_review.md`
+5. 参考 `${CLAUDE_SKILL_DIR}/prompts/review_design_examples_builder.md` 生成 `/tmp/{slug}_examples.md`
+6. 用以下命令写入单独目录：
+
+```bash
+python3 ${CLAUDE_SKILL_DIR}/tools/skill_writer.py \
+  --action create-reviewer \
+  --reviewer-type design \
+  --slug {slug} \
+  --meta /tmp/{slug}_meta.json \
+  --review /tmp/{slug}_review.md \
+  --examples /tmp/{slug}_examples.md \
+  --base-dir ./reviewers/design
+```
+
+---
+
 ## 进化模式：对话纠正
 
 用户表达"不对"/"应该是"时：
@@ -495,15 +557,47 @@ user-invocable: true
 python3 ${CLAUDE_SKILL_DIR}/tools/skill_writer.py --action list --base-dir ./colleagues
 ```
 
+`/list-pr-reviewers`：
+```bash
+python3 ${CLAUDE_SKILL_DIR}/tools/skill_writer.py --action list --base-dir ./reviewers/pr
+```
+
+`/list-design-reviewers`：
+```bash
+python3 ${CLAUDE_SKILL_DIR}/tools/skill_writer.py --action list --base-dir ./reviewers/design
+```
+
 `/colleague-rollback {slug} {version}`：
 ```bash
 python3 ${CLAUDE_SKILL_DIR}/tools/version_manager.py --action rollback --slug {slug} --version {version} --base-dir ./colleagues
+```
+
+`/reviewer-rollback pr {slug} {version}`：
+```bash
+python3 ${CLAUDE_SKILL_DIR}/tools/version_manager.py --action rollback --slug {slug} --version {version} --base-dir ./reviewers/pr
+```
+
+`/reviewer-rollback design {slug} {version}`：
+```bash
+python3 ${CLAUDE_SKILL_DIR}/tools/version_manager.py --action rollback --slug {slug} --version {version} --base-dir ./reviewers/design
 ```
 
 `/delete-colleague {slug}`：
 确认后执行：
 ```bash
 rm -rf colleagues/{slug}
+```
+
+`/delete-pr-reviewer {slug}`：
+确认后执行：
+```bash
+rm -rf reviewers/pr/{slug}
+```
+
+`/delete-design-reviewer {slug}`：
+确认后执行：
+```bash
+rm -rf reviewers/design/{slug}
 ```
 
 ---
@@ -529,6 +623,19 @@ Enter evolution mode when the user says:
 
 List all generated colleagues when the user says `/list-colleagues`.
 
+Activate PR reviewer generation when the user says:
+- `/create-pr-reviewer`
+- "Help me create a PR reviewer"
+- "Clone this colleague's code review style"
+
+Activate design reviewer generation when the user says:
+- `/create-design-reviewer`
+- "Help me create a design reviewer"
+- "Clone this colleague's architecture review style"
+
+List PR reviewers when the user says `/list-pr-reviewers`.
+List design reviewers when the user says `/list-design-reviewers`.
+
 ---
 
 ## Tool Usage Rules
@@ -552,6 +659,7 @@ This Skill runs in the Claude Code environment with the following tools:
 
 **Base directory**: Skill files are written to `./colleagues/{slug}/` (relative to the project directory).
 For a global path, use `--base-dir ~/.openclaw/workspace/skills/colleagues`.
+PR reviewers are written to `./reviewers/pr/{slug}/`, and design reviewers are written to `./reviewers/design/{slug}/`.
 
 ---
 
@@ -976,6 +1084,54 @@ When user provides new files or text:
 
 ---
 
+## Main Flow: Create a PR Reviewer Skill
+
+PR reviewers are **review-only clones**. They emulate how a person evaluates code diffs, severity, and approval thresholds, but they do not replace the full colleague Skill and do not act as a general worker/persona clone.
+
+1. Refer to `${CLAUDE_SKILL_DIR}/prompts/review_pr_intake.md` to collect the minimum required reviewer context
+2. Import review-relevant material: PR comments, review threads, technical discussions, and incident commentary
+3. Refer to `${CLAUDE_SKILL_DIR}/prompts/review_pr_analyzer.md` to extract severity rules, blocker patterns, approval thresholds, recurring issues, and phrasing style
+4. Refer to `${CLAUDE_SKILL_DIR}/prompts/review_pr_builder.md` to generate `/tmp/{slug}_review.md`
+5. Refer to `${CLAUDE_SKILL_DIR}/prompts/review_pr_examples_builder.md` to generate `/tmp/{slug}_examples.md`
+6. Write the reviewer into its isolated directory:
+
+```bash
+python3 ${CLAUDE_SKILL_DIR}/tools/skill_writer.py \
+  --action create-reviewer \
+  --reviewer-type pr \
+  --slug {slug} \
+  --meta /tmp/{slug}_meta.json \
+  --review /tmp/{slug}_review.md \
+  --examples /tmp/{slug}_examples.md \
+  --base-dir ./reviewers/pr
+```
+
+---
+
+## Main Flow: Create a Design Reviewer Skill
+
+Design reviewers are also **review-only clones**. They emulate how a person evaluates RFCs, API contracts, rollout plans, and architecture tradeoffs, but they do not replace the full colleague Skill and do not act as a general worker/persona clone.
+
+1. Refer to `${CLAUDE_SKILL_DIR}/prompts/review_design_intake.md` to collect the minimum required reviewer context
+2. Import design-review material: RFC comments, design docs, API reviews, planning threads, and architecture discussions
+3. Refer to `${CLAUDE_SKILL_DIR}/prompts/review_design_analyzer.md` to extract evaluation criteria, repeated questions, red flags, and rollout/ownership/observability expectations
+4. Refer to `${CLAUDE_SKILL_DIR}/prompts/review_design_builder.md` to generate `/tmp/{slug}_review.md`
+5. Refer to `${CLAUDE_SKILL_DIR}/prompts/review_design_examples_builder.md` to generate `/tmp/{slug}_examples.md`
+6. Write the reviewer into its isolated directory:
+
+```bash
+python3 ${CLAUDE_SKILL_DIR}/tools/skill_writer.py \
+  --action create-reviewer \
+  --reviewer-type design \
+  --slug {slug} \
+  --meta /tmp/{slug}_meta.json \
+  --review /tmp/{slug}_review.md \
+  --examples /tmp/{slug}_examples.md \
+  --base-dir ./reviewers/design
+```
+
+---
+
 ## Evolution Mode: Conversation Correction
 
 When user expresses "that's wrong" / "he should be":
@@ -995,13 +1151,45 @@ When user expresses "that's wrong" / "he should be":
 python3 ${CLAUDE_SKILL_DIR}/tools/skill_writer.py --action list --base-dir ./colleagues
 ```
 
+`/list-pr-reviewers`:
+```bash
+python3 ${CLAUDE_SKILL_DIR}/tools/skill_writer.py --action list --base-dir ./reviewers/pr
+```
+
+`/list-design-reviewers`:
+```bash
+python3 ${CLAUDE_SKILL_DIR}/tools/skill_writer.py --action list --base-dir ./reviewers/design
+```
+
 `/colleague-rollback {slug} {version}`:
 ```bash
 python3 ${CLAUDE_SKILL_DIR}/tools/version_manager.py --action rollback --slug {slug} --version {version} --base-dir ./colleagues
+```
+
+`/reviewer-rollback pr {slug} {version}`:
+```bash
+python3 ${CLAUDE_SKILL_DIR}/tools/version_manager.py --action rollback --slug {slug} --version {version} --base-dir ./reviewers/pr
+```
+
+`/reviewer-rollback design {slug} {version}`:
+```bash
+python3 ${CLAUDE_SKILL_DIR}/tools/version_manager.py --action rollback --slug {slug} --version {version} --base-dir ./reviewers/design
 ```
 
 `/delete-colleague {slug}`:
 After confirmation:
 ```bash
 rm -rf colleagues/{slug}
+```
+
+`/delete-pr-reviewer {slug}`:
+After confirmation:
+```bash
+rm -rf reviewers/pr/{slug}
+```
+
+`/delete-design-reviewer {slug}`:
+After confirmation:
+```bash
+rm -rf reviewers/design/{slug}
 ```

--- a/docs/superpowers/plans/2026-04-13-reviewer-clone-generators.md
+++ b/docs/superpowers/plans/2026-04-13-reviewer-clone-generators.md
@@ -1,0 +1,1152 @@
+# Reviewer Clone Generators Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `/create-pr-reviewer` and `/create-design-reviewer` as review-only generator flows, keep `/create-colleague` unchanged, and document the new command surface in `README.md`.
+
+**Architecture:** Extend the existing shared writer and versioning utilities to support reviewer artifacts in separate directories, add dedicated reviewer prompt files, and route the new commands through the main `SKILL.md`. Verify behavior with a small `unittest` suite that covers writer behavior, version rollback, prompt inventory, and command-surface docs.
+
+**Tech Stack:** Python 3.9+, stdlib `unittest`, existing markdown prompt system, existing `skill_writer.py` and `version_manager.py`
+
+---
+
+## Planned File Map
+
+### Create
+
+- `tests/test_skill_writer_reviewers.py`
+- `tests/test_version_manager_reviewers.py`
+- `tests/test_reviewer_prompt_inventory.py`
+- `tests/test_command_surface_docs.py`
+- `prompts/review_pr_intake.md`
+- `prompts/review_pr_analyzer.md`
+- `prompts/review_pr_builder.md`
+- `prompts/review_pr_examples_builder.md`
+- `prompts/review_design_intake.md`
+- `prompts/review_design_analyzer.md`
+- `prompts/review_design_builder.md`
+- `prompts/review_design_examples_builder.md`
+
+### Modify
+
+- `tools/skill_writer.py`
+- `tools/version_manager.py`
+- `SKILL.md`
+- `README.md`
+
+### Verify
+
+- `python3 -m unittest discover -s tests -p 'test_*.py' -v`
+- `python3 -m py_compile tools/skill_writer.py tools/version_manager.py`
+- `git diff --check`
+
+---
+
+### Task 1: Add Failing Tests For Reviewer Writer Support
+
+**Files:**
+- Create: `tests/test_skill_writer_reviewers.py`
+- Test: `tools/skill_writer.py`
+
+- [ ] **Step 1: Write the failing test file for reviewer creation and listing**
+
+```python
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILL_WRITER = REPO_ROOT / "tools" / "skill_writer.py"
+
+
+class SkillWriterReviewerTests(unittest.TestCase):
+    def test_create_pr_reviewer_writes_expected_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            meta_path = tmp_path / "meta.json"
+            review_path = tmp_path / "review.md"
+            examples_path = tmp_path / "examples.md"
+            base_dir = tmp_path / "reviewers" / "pr"
+
+            meta_path.write_text(
+                json.dumps(
+                    {
+                        "name": "alex",
+                        "language": "en",
+                        "profile": {"company": "Acme", "role": "backend engineer"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            review_path.write_text(
+                "# alex - PR Review Rules\n\n## Severity\n\n- Block on correctness regressions.\n",
+                encoding="utf-8",
+            )
+            examples_path.write_text(
+                "# alex - PR Review Examples\n\n- blocker: missing rollback path\n",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SKILL_WRITER),
+                    "--action",
+                    "create-reviewer",
+                    "--reviewer-type",
+                    "pr",
+                    "--slug",
+                    "alex",
+                    "--meta",
+                    str(meta_path),
+                    "--review",
+                    str(review_path),
+                    "--examples",
+                    str(examples_path),
+                    "--base-dir",
+                    str(base_dir),
+                ],
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            reviewer_dir = base_dir / "alex"
+            self.assertTrue((reviewer_dir / "SKILL.md").exists())
+            self.assertTrue((reviewer_dir / "review.md").exists())
+            self.assertTrue((reviewer_dir / "examples.md").exists())
+            self.assertTrue((reviewer_dir / "meta.json").exists())
+
+            meta = json.loads((reviewer_dir / "meta.json").read_text(encoding="utf-8"))
+            self.assertEqual(meta["reviewer_type"], "pr")
+
+    def test_list_action_reads_reviewer_directories(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            reviewer_dir = tmp_path / "reviewers" / "design" / "morgan"
+            reviewer_dir.mkdir(parents=True)
+            (reviewer_dir / "meta.json").write_text(
+                json.dumps(
+                    {
+                        "name": "morgan",
+                        "slug": "morgan",
+                        "language": "en",
+                        "reviewer_type": "design",
+                        "version": "v1",
+                        "updated_at": "2026-04-13T00:00:00+00:00",
+                        "corrections_count": 0,
+                        "profile": {"company": "Acme", "role": "staff engineer"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SKILL_WRITER),
+                    "--action",
+                    "list",
+                    "--base-dir",
+                    str(tmp_path / "reviewers" / "design"),
+                ],
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("morgan", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+python3 -m unittest tests.test_skill_writer_reviewers -v
+```
+
+Expected:
+
+```text
+FAIL: test_create_pr_reviewer_writes_expected_files
+error output mentions invalid choice 'create-reviewer' or missing reviewer arguments
+```
+
+- [ ] **Step 3: Implement reviewer creation and listing support in `tools/skill_writer.py`**
+
+Add reviewer-specific helpers near the existing writer helpers:
+
+```python
+REVIEWER_CONFIG = {
+    "pr": {
+        "title": "PR Reviewer",
+        "skill_name_prefix": "pr-reviewer",
+        "description_suffix": "PR/code review clone",
+    },
+    "design": {
+        "title": "Design Reviewer",
+        "skill_name_prefix": "design-reviewer",
+        "description_suffix": "design/architecture review clone",
+    },
+}
+
+
+def render_reviewer_skill_md(
+    reviewer_type: str,
+    slug: str,
+    name: str,
+    identity: str,
+    review_content: str,
+    examples_content: str,
+) -> str:
+    config = REVIEWER_CONFIG[reviewer_type]
+    return f\"\"\"\
+---
+name: {config['skill_name_prefix']}_{slug}
+description: {name}, {config['description_suffix']}
+user-invocable: true
+---
+
+# {name} - {config['title']}
+
+{identity}
+
+---
+
+## Review Rules
+
+{review_content}
+
+---
+
+## Review Examples
+
+{examples_content}
+
+---
+
+## Execution Rules
+
+1. Stay in review mode only.
+2. Review submitted material using the heuristics above.
+3. Preserve the reviewer's severity and phrasing style.
+4. Do not switch into implementation mode unless the user explicitly asks for implementation outside this skill.
+\"\"\"
+
+
+def create_reviewer_skill(
+    base_dir: Path,
+    reviewer_type: str,
+    slug: str,
+    meta: dict,
+    review_content: str,
+    examples_content: str,
+) -> Path:
+    skill_dir = base_dir / slug
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "versions").mkdir(exist_ok=True)
+    (skill_dir / "knowledge").mkdir(exist_ok=True)
+    (skill_dir / "review.md").write_text(review_content, encoding="utf-8")
+    (skill_dir / "examples.md").write_text(examples_content, encoding="utf-8")
+
+    language = get_language(meta)
+    name = meta.get("name", slug)
+    identity = build_identity_string(meta, language)
+    skill_md = render_reviewer_skill_md(
+        reviewer_type=reviewer_type,
+        slug=slug,
+        name=name,
+        identity=identity,
+        review_content=review_content,
+        examples_content=examples_content,
+    )
+    (skill_dir / "SKILL.md").write_text(skill_md, encoding="utf-8")
+
+    now = datetime.now(timezone.utc).isoformat()
+    meta["slug"] = slug
+    meta["reviewer_type"] = reviewer_type
+    meta.setdefault("created_at", now)
+    meta["updated_at"] = now
+    meta["version"] = "v1"
+    meta.setdefault("corrections_count", 0)
+    meta.setdefault("language", language)
+    (skill_dir / "meta.json").write_text(
+        json.dumps(meta, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    return skill_dir
+```
+
+Extend CLI parsing so these reviewer arguments are accepted:
+
+```python
+parser.add_argument(
+    "--action",
+    required=True,
+    choices=["create", "update", "list", "create-reviewer", "update-reviewer"],
+)
+parser.add_argument("--reviewer-type", choices=["pr", "design"])
+parser.add_argument("--review", help="path to the review.md content file")
+parser.add_argument("--examples", help="path to the examples.md content file")
+parser.add_argument("--review-patch", help="path to the incremental review.md patch file")
+parser.add_argument("--examples-patch", help="path to the incremental examples.md patch file")
+```
+
+Handle `create-reviewer` in `main()`:
+
+```python
+elif args.action == "create-reviewer":
+    if not args.reviewer_type:
+        print("error: create-reviewer requires --reviewer-type", file=sys.stderr)
+        sys.exit(1)
+    if not args.slug and not args.name:
+        print("error: create-reviewer requires --slug or --name", file=sys.stderr)
+        sys.exit(1)
+
+    meta = json.loads(Path(args.meta).read_text(encoding="utf-8")) if args.meta else {}
+    if args.name:
+        meta["name"] = args.name
+    slug = args.slug or slugify(meta.get("name", "reviewer"))
+    review_content = Path(args.review).read_text(encoding="utf-8") if args.review else ""
+    examples_content = Path(args.examples).read_text(encoding="utf-8") if args.examples else ""
+
+    skill_dir = create_reviewer_skill(
+        base_dir=base_dir,
+        reviewer_type=args.reviewer_type,
+        slug=slug,
+        meta=meta,
+        review_content=review_content,
+        examples_content=examples_content,
+    )
+    print(f"Created {args.reviewer_type} reviewer: {skill_dir}")
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run:
+
+```bash
+python3 -m unittest tests.test_skill_writer_reviewers -v
+```
+
+Expected:
+
+```text
+OK
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_skill_writer_reviewers.py tools/skill_writer.py
+git commit -m "feat: add reviewer writer support"
+```
+
+---
+
+### Task 2: Add Failing Tests For Reviewer Version Backup And Rollback
+
+**Files:**
+- Create: `tests/test_version_manager_reviewers.py`
+- Modify: `tools/version_manager.py`
+- Test: `tools/version_manager.py`
+
+- [ ] **Step 1: Write the failing reviewer version-manager tests**
+
+```python
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+VERSION_MANAGER = REPO_ROOT / "tools" / "version_manager.py"
+
+
+class VersionManagerReviewerTests(unittest.TestCase):
+    def test_backup_and_rollback_restore_reviewer_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            reviewer_dir = tmp_path / "reviewers" / "pr" / "alex"
+            (reviewer_dir / "versions").mkdir(parents=True)
+            (reviewer_dir / "SKILL.md").write_text("v1 skill", encoding="utf-8")
+            (reviewer_dir / "review.md").write_text("v1 review", encoding="utf-8")
+            (reviewer_dir / "examples.md").write_text("v1 examples", encoding="utf-8")
+            (reviewer_dir / "meta.json").write_text(
+                json.dumps({"version": "v1", "updated_at": "2026-04-13T00:00:00+00:00"}),
+                encoding="utf-8",
+            )
+
+            backup = subprocess.run(
+                [
+                    sys.executable,
+                    str(VERSION_MANAGER),
+                    "--action",
+                    "backup",
+                    "--slug",
+                    "alex",
+                    "--base-dir",
+                    str(tmp_path / "reviewers" / "pr"),
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(backup.returncode, 0, backup.stderr)
+            self.assertTrue((reviewer_dir / "versions" / "v1" / "review.md").exists())
+            self.assertTrue((reviewer_dir / "versions" / "v1" / "examples.md").exists())
+
+            (reviewer_dir / "SKILL.md").write_text("v2 skill", encoding="utf-8")
+            (reviewer_dir / "review.md").write_text("v2 review", encoding="utf-8")
+            (reviewer_dir / "examples.md").write_text("v2 examples", encoding="utf-8")
+            (reviewer_dir / "meta.json").write_text(
+                json.dumps({"version": "v2", "updated_at": "2026-04-13T01:00:00+00:00"}),
+                encoding="utf-8",
+            )
+
+            rollback = subprocess.run(
+                [
+                    sys.executable,
+                    str(VERSION_MANAGER),
+                    "--action",
+                    "rollback",
+                    "--slug",
+                    "alex",
+                    "--version",
+                    "v1",
+                    "--base-dir",
+                    str(tmp_path / "reviewers" / "pr"),
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(rollback.returncode, 0, rollback.stderr)
+            self.assertEqual((reviewer_dir / "review.md").read_text(encoding="utf-8"), "v1 review")
+            self.assertEqual((reviewer_dir / "examples.md").read_text(encoding="utf-8"), "v1 examples")
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+python3 -m unittest tests.test_version_manager_reviewers -v
+```
+
+Expected:
+
+```text
+FAIL: review.md or examples.md were not archived/restored
+```
+
+- [ ] **Step 3: Generalize `tools/version_manager.py` to detect reviewer files**
+
+Add a helper above `rollback()`:
+
+```python
+def managed_content_files(skill_dir: Path) -> tuple[str, ...]:
+    reviewer_files = ("SKILL.md", "review.md", "examples.md")
+    colleague_files = ("SKILL.md", "work.md", "persona.md")
+
+    if any((skill_dir / name).exists() for name in ("review.md", "examples.md")):
+        return reviewer_files
+    return colleague_files
+```
+
+Use it in `rollback()` and `backup_current_version()`:
+
+```python
+for fname in managed_content_files(skill_dir):
+    src = skill_dir / fname
+    if src.exists():
+        shutil.copy2(src, backup_dir / fname)
+```
+
+and:
+
+```python
+for fname in managed_content_files(skill_dir):
+    src = version_dir / fname
+    if src.exists():
+        shutil.copy2(src, skill_dir / fname)
+        restored_files.append(fname)
+```
+
+Update the module docstring and parser help to use generic wording like `generated skills` instead of `colleague skills`.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run:
+
+```bash
+python3 -m unittest tests.test_version_manager_reviewers -v
+```
+
+Expected:
+
+```text
+OK
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_version_manager_reviewers.py tools/version_manager.py
+git commit -m "feat: support reviewer version rollback"
+```
+
+---
+
+### Task 3: Add Reviewer Prompt Files With Inventory Tests
+
+**Files:**
+- Create: `tests/test_reviewer_prompt_inventory.py`
+- Create: `prompts/review_pr_intake.md`
+- Create: `prompts/review_pr_analyzer.md`
+- Create: `prompts/review_pr_builder.md`
+- Create: `prompts/review_pr_examples_builder.md`
+- Create: `prompts/review_design_intake.md`
+- Create: `prompts/review_design_analyzer.md`
+- Create: `prompts/review_design_builder.md`
+- Create: `prompts/review_design_examples_builder.md`
+
+- [ ] **Step 1: Write the failing prompt inventory test**
+
+```python
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+EXPECTED_PROMPTS = [
+    "prompts/review_pr_intake.md",
+    "prompts/review_pr_analyzer.md",
+    "prompts/review_pr_builder.md",
+    "prompts/review_pr_examples_builder.md",
+    "prompts/review_design_intake.md",
+    "prompts/review_design_analyzer.md",
+    "prompts/review_design_builder.md",
+    "prompts/review_design_examples_builder.md",
+]
+
+
+class ReviewerPromptInventoryTests(unittest.TestCase):
+    def test_all_reviewer_prompt_files_exist(self):
+        for relative_path in EXPECTED_PROMPTS:
+            with self.subTest(path=relative_path):
+                self.assertTrue((REPO_ROOT / relative_path).exists(), relative_path)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+python3 -m unittest tests.test_reviewer_prompt_inventory -v
+```
+
+Expected:
+
+```text
+FAIL: one or more prompt files do not exist
+```
+
+- [ ] **Step 3: Create the PR reviewer prompt files**
+
+`prompts/review_pr_intake.md`
+
+```md
+# PR Reviewer Intake
+
+## Goal
+
+Collect only the information needed to build a PR/code-review clone.
+
+## Questions
+
+1. Reviewer alias / slug
+2. Reviewer context in one sentence: company, level, role, stack
+3. What materials are available: PR comments, review threads, technical chats, incident discussions
+
+## Summary
+
+Show the collected summary and confirm before analysis.
+```
+
+`prompts/review_pr_analyzer.md`
+
+```md
+# PR Reviewer Analyzer
+
+## Goal
+
+Extract how the reviewer judges diffs.
+
+## Extract
+
+- Severity model: blocker / major / minor / nit
+- Recurring issue categories
+- Approval thresholds
+- Questions asked before approval
+- Stack-specific patterns when supported by evidence
+- Tone and framing of comments
+
+## Output
+
+Write concrete review rules only. Mark under-evidenced areas explicitly.
+```
+
+`prompts/review_pr_builder.md`
+
+```md
+# PR Reviewer Builder
+
+## Goal
+
+Generate `review.md` for a PR reviewer clone.
+
+## Required Sections
+
+- Scope
+- Review order
+- Severity rules
+- Common blockers
+- Common non-blockers
+- Approval / request-changes / ask-for-context behavior
+- Review-only execution rules
+```
+
+`prompts/review_pr_examples_builder.md`
+
+```md
+# PR Reviewer Examples Builder
+
+## Goal
+
+Generate `examples.md` for a PR reviewer clone.
+
+## Required Examples
+
+- blocker comment
+- major issue comment
+- nit comment
+- asks-for-context comment
+- approval comment
+```
+
+- [ ] **Step 4: Create the design reviewer prompt files**
+
+`prompts/review_design_intake.md`
+
+```md
+# Design Reviewer Intake
+
+## Goal
+
+Collect only the information needed to build a design-review clone.
+
+## Questions
+
+1. Reviewer alias / slug
+2. Reviewer context in one sentence: company, level, role, architecture scope
+3. What materials are available: RFC comments, design docs, API reviews, planning threads
+
+## Summary
+
+Show the collected summary and confirm before analysis.
+```
+
+`prompts/review_design_analyzer.md`
+
+```md
+# Design Reviewer Analyzer
+
+## Goal
+
+Extract how the reviewer evaluates design docs and architecture.
+
+## Extract
+
+- Questions they always ask
+- Tradeoffs they privilege
+- Risks they look for first
+- Contract / API concerns
+- Rollout, ownership, observability, reversibility expectations
+- Tone and framing of comments
+
+## Output
+
+Write concrete design-review rules only. Mark under-evidenced areas explicitly.
+```
+
+`prompts/review_design_builder.md`
+
+```md
+# Design Reviewer Builder
+
+## Goal
+
+Generate `review.md` for a design reviewer clone.
+
+## Required Sections
+
+- Scope
+- Review order
+- Core evaluation criteria
+- Red flags
+- Questions before approval
+- Approval / request-changes / ask-for-context behavior
+- Review-only execution rules
+```
+
+`prompts/review_design_examples_builder.md`
+
+```md
+# Design Reviewer Examples Builder
+
+## Goal
+
+Generate `examples.md` for a design reviewer clone.
+
+## Required Examples
+
+- asks-for-missing-context comment
+- contract-risk comment
+- rollout-risk comment
+- ownership/observability comment
+- approval comment
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run:
+
+```bash
+python3 -m unittest tests.test_reviewer_prompt_inventory -v
+```
+
+Expected:
+
+```text
+OK
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/test_reviewer_prompt_inventory.py prompts/review_*.md
+git commit -m "feat: add reviewer prompt set"
+```
+
+---
+
+### Task 4: Route Reviewer Commands Through `SKILL.md`
+
+**Files:**
+- Create: `tests/test_command_surface_docs.py`
+- Modify: `SKILL.md`
+
+- [ ] **Step 1: Write the failing command-surface test for `SKILL.md`**
+
+```python
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILL_MD = REPO_ROOT / "SKILL.md"
+
+
+class CommandSurfaceDocsTests(unittest.TestCase):
+    def test_skill_md_mentions_reviewer_commands_and_prompts(self):
+        text = SKILL_MD.read_text(encoding="utf-8")
+        required_tokens = [
+            "/create-pr-reviewer",
+            "/create-design-reviewer",
+            "/list-pr-reviewers",
+            "/list-design-reviewers",
+            "/reviewer-rollback pr {slug} {version}",
+            "/reviewer-rollback design {slug} {version}",
+            "/delete-pr-reviewer {slug}",
+            "/delete-design-reviewer {slug}",
+            "prompts/review_pr_intake.md",
+            "prompts/review_design_intake.md",
+        ]
+        for token in required_tokens:
+            with self.subTest(token=token):
+                self.assertIn(token, text)
+
+
+if __name__ == "__main__":
+    unittest.main()
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run:
+
+```bash
+python3 -m unittest tests.test_command_surface_docs.CommandSurfaceDocsTests.test_skill_md_mentions_reviewer_commands_and_prompts -v
+```
+
+Expected:
+
+```text
+FAIL: missing /create-pr-reviewer and reviewer prompt references
+```
+
+- [ ] **Step 3: Update the English command routing in `SKILL.md`**
+
+Add trigger conditions near the English command list:
+
+```md
+Activate PR reviewer generation when the user says:
+- `/create-pr-reviewer`
+- "Help me create a PR reviewer"
+- "Clone this colleague's code review style"
+
+Activate design reviewer generation when the user says:
+- `/create-design-reviewer`
+- "Help me create a design reviewer"
+- "Clone this colleague's architecture review style"
+
+List PR reviewers when the user says `/list-pr-reviewers`.
+List design reviewers when the user says `/list-design-reviewers`.
+```
+
+Add reviewer-only generation sections that reference:
+
+```md
+`${CLAUDE_SKILL_DIR}/prompts/review_pr_intake.md`
+`${CLAUDE_SKILL_DIR}/prompts/review_pr_analyzer.md`
+`${CLAUDE_SKILL_DIR}/prompts/review_pr_builder.md`
+`${CLAUDE_SKILL_DIR}/prompts/review_pr_examples_builder.md`
+`${CLAUDE_SKILL_DIR}/prompts/review_design_intake.md`
+`${CLAUDE_SKILL_DIR}/prompts/review_design_analyzer.md`
+`${CLAUDE_SKILL_DIR}/prompts/review_design_builder.md`
+`${CLAUDE_SKILL_DIR}/prompts/review_design_examples_builder.md`
+```
+
+Route writer commands to the separate directories:
+
+```bash
+python3 ${CLAUDE_SKILL_DIR}/tools/skill_writer.py \
+  --action create-reviewer \
+  --reviewer-type pr \
+  --slug {slug} \
+  --meta /tmp/{slug}_meta.json \
+  --review /tmp/{slug}_review.md \
+  --examples /tmp/{slug}_examples.md \
+  --base-dir ./reviewers/pr
+```
+
+and:
+
+```bash
+python3 ${CLAUDE_SKILL_DIR}/tools/skill_writer.py \
+  --action create-reviewer \
+  --reviewer-type design \
+  --slug {slug} \
+  --meta /tmp/{slug}_meta.json \
+  --review /tmp/{slug}_review.md \
+  --examples /tmp/{slug}_examples.md \
+  --base-dir ./reviewers/design
+```
+
+Add management command snippets:
+
+```bash
+python3 ${CLAUDE_SKILL_DIR}/tools/version_manager.py --action rollback --slug {slug} --version {version} --base-dir ./reviewers/pr
+python3 ${CLAUDE_SKILL_DIR}/tools/version_manager.py --action rollback --slug {slug} --version {version} --base-dir ./reviewers/design
+rm -rf reviewers/pr/{slug}
+rm -rf reviewers/design/{slug}
+```
+
+- [ ] **Step 4: Update the Chinese command routing section in `SKILL.md` with the same command surface**
+
+Add the same reviewer commands to the Chinese branch so both language paths stay structurally aligned.
+
+- [ ] **Step 5: Run the `SKILL.md` command-surface test to verify it passes**
+
+Run:
+
+```bash
+python3 -m unittest tests.test_command_surface_docs.CommandSurfaceDocsTests.test_skill_md_mentions_reviewer_commands_and_prompts -v
+```
+
+Expected:
+
+```text
+OK
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/test_command_surface_docs.py SKILL.md
+git commit -m "feat: route reviewer generators through main skill"
+```
+
+---
+
+### Task 5: Document Reviewer Commands In `README.md`
+
+**Files:**
+- Modify: `README.md`
+- Test: `tests/test_command_surface_docs.py`
+
+- [ ] **Step 1: Extend the docs test to check `README.md`**
+
+Add to `tests/test_command_surface_docs.py`:
+
+```python
+README_MD = REPO_ROOT / "README.md"
+
+
+class ReadmeReviewerCommandsTests(unittest.TestCase):
+    def test_readme_documents_reviewer_commands(self):
+        text = README_MD.read_text(encoding="utf-8")
+        required_tokens = [
+            "Reviewer Commands",
+            "/create-pr-reviewer",
+            "/create-design-reviewer",
+            "/list-pr-reviewers",
+            "/list-design-reviewers",
+            "/reviewer-rollback pr {slug} {version}",
+            "/reviewer-rollback design {slug} {version}",
+            "/delete-pr-reviewer {slug}",
+            "/delete-design-reviewer {slug}",
+        ]
+        for token in required_tokens:
+            with self.subTest(token=token):
+                self.assertIn(token, text)
+```
+
+- [ ] **Step 2: Run the README test to verify it fails**
+
+Run:
+
+```bash
+python3 -m unittest tests.test_command_surface_docs.ReadmeReviewerCommandsTests.test_readme_documents_reviewer_commands -v
+```
+
+Expected:
+
+```text
+FAIL: Reviewer Commands section not found
+```
+
+- [ ] **Step 3: Add the reviewer command surface to `README.md`**
+
+Insert a new subsection under `### Commands`:
+
+```md
+| Command | Description |
+|---------|-------------|
+| `/list-colleagues` | List all colleague Skills |
+| `/{slug}` | Invoke full Skill (Persona + Work) |
+| `/{slug}-work` | Work capabilities only |
+| `/{slug}-persona` | Persona only |
+| `/colleague-rollback {slug} {version}` | Rollback to a previous version |
+| `/delete-colleague {slug}` | Delete |
+
+### Reviewer Commands
+
+| Command | Description |
+|---------|-------------|
+| `/create-pr-reviewer` | Create a review-only clone for PR/code review |
+| `/create-design-reviewer` | Create a review-only clone for RFC/design/architecture review |
+| `/list-pr-reviewers` | List generated PR reviewers |
+| `/list-design-reviewers` | List generated design reviewers |
+| `/reviewer-rollback pr {slug} {version}` | Roll back a PR reviewer |
+| `/reviewer-rollback design {slug} {version}` | Roll back a design reviewer |
+| `/delete-pr-reviewer {slug}` | Delete a PR reviewer |
+| `/delete-design-reviewer {slug}` | Delete a design reviewer |
+```
+
+Also add one short explanatory paragraph immediately below:
+
+```md
+Reviewer clones are review-only. They emulate how a colleague evaluates code or design material, but they do not replace the full colleague Skill or act as a general worker/persona clone.
+```
+
+- [ ] **Step 4: Run the docs tests to verify they pass**
+
+Run:
+
+```bash
+python3 -m unittest tests.test_command_surface_docs -v
+```
+
+Expected:
+
+```text
+OK
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md tests/test_command_surface_docs.py
+git commit -m "docs: add reviewer command surface"
+```
+
+---
+
+### Task 6: Run Full Verification And Smoke Tests
+
+**Files:**
+- Verify only
+
+- [ ] **Step 1: Run the full unit test suite**
+
+Run:
+
+```bash
+python3 -m unittest discover -s tests -p 'test_*.py' -v
+```
+
+Expected:
+
+```text
+OK
+```
+
+- [ ] **Step 2: Compile the modified Python tools**
+
+Run:
+
+```bash
+python3 -m py_compile tools/skill_writer.py tools/version_manager.py
+```
+
+Expected:
+
+```text
+no output
+```
+
+- [ ] **Step 3: Run a PR reviewer smoke test in a temp directory**
+
+Run:
+
+```bash
+tmpdir="$(mktemp -d)"
+cat > "$tmpdir/meta.json" <<'EOF'
+{"name":"alex","language":"en","profile":{"company":"Acme","role":"backend engineer"}}
+EOF
+cat > "$tmpdir/review.md" <<'EOF'
+# alex - PR Review Rules
+
+## Severity
+
+- Block on correctness regressions.
+EOF
+cat > "$tmpdir/examples.md" <<'EOF'
+# alex - PR Review Examples
+
+- blocker: missing rollback path
+EOF
+python3 tools/skill_writer.py \
+  --action create-reviewer \
+  --reviewer-type pr \
+  --slug alex \
+  --meta "$tmpdir/meta.json" \
+  --review "$tmpdir/review.md" \
+  --examples "$tmpdir/examples.md" \
+  --base-dir "$tmpdir/reviewers/pr"
+test -f "$tmpdir/reviewers/pr/alex/SKILL.md"
+```
+
+Expected:
+
+```text
+Created pr reviewer: ...
+```
+
+- [ ] **Step 4: Run a design reviewer smoke test in a temp directory**
+
+Run:
+
+```bash
+tmpdir="$(mktemp -d)"
+cat > "$tmpdir/meta.json" <<'EOF'
+{"name":"morgan","language":"en","profile":{"company":"Acme","role":"staff engineer"}}
+EOF
+cat > "$tmpdir/review.md" <<'EOF'
+# morgan - Design Review Rules
+
+## Core Criteria
+
+- Ask for rollout and observability before approval.
+EOF
+cat > "$tmpdir/examples.md" <<'EOF'
+# morgan - Design Review Examples
+
+- ask-for-context: what is the rollback path?
+EOF
+python3 tools/skill_writer.py \
+  --action create-reviewer \
+  --reviewer-type design \
+  --slug morgan \
+  --meta "$tmpdir/meta.json" \
+  --review "$tmpdir/review.md" \
+  --examples "$tmpdir/examples.md" \
+  --base-dir "$tmpdir/reviewers/design"
+test -f "$tmpdir/reviewers/design/morgan/SKILL.md"
+```
+
+Expected:
+
+```text
+Created design reviewer: ...
+```
+
+- [ ] **Step 5: Run diff hygiene checks**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected:
+
+```text
+no output
+```
+
+- [ ] **Step 6: Commit the final integration**
+
+```bash
+git add tests/ prompts/ SKILL.md README.md tools/skill_writer.py tools/version_manager.py
+git commit -m "feat: add reviewer clone generators"
+```
+
+---
+
+## Self-Review
+
+- Spec coverage: the plan covers separate PR/design reviewer generators, separate directories, prompt files, shared writer updates, version rollback, main-skill routing, and README command documentation.
+- Placeholder scan: no `TODO`, `TBD`, or “implement later” placeholders remain.
+- Type consistency: the plan uses one reviewer writer interface (`create-reviewer`, `update-reviewer`, `--reviewer-type`) and one directory scheme (`reviewers/pr`, `reviewers/design`) throughout.

--- a/docs/superpowers/specs/2026-04-13-reviewer-clone-generators-design.md
+++ b/docs/superpowers/specs/2026-04-13-reviewer-clone-generators-design.md
@@ -1,0 +1,408 @@
+# Reviewer Clone Generators Design
+
+- Date: 2026-04-13
+- Status: Approved design, pending implementation
+- Repo: `colleague-skill`
+
+## Summary
+
+Add two new review-only generator flows to the existing skill system without changing the behavior of `/create-colleague`:
+
+- `/create-pr-reviewer`
+- `/create-design-reviewer`
+
+These generators create specialized reviewer clones that emulate how a specific colleague reviews code or design material, but do not emulate the colleague broadly as a full persona or worker.
+
+The implementation must keep the existing colleague skill intact, route the new commands through the main `SKILL.md`, reuse existing ingestion tooling where possible, and document the new command surface in `README.md` with short descriptions.
+
+## Goals
+
+- Add a PR/code-review generator for cloning a colleague's review behavior on diffs and implementation details.
+- Add a design/architecture-review generator for cloning a colleague's review behavior on RFCs, APIs, design docs, and architecture decisions.
+- Keep reviewer outputs review-only and separate from the general colleague skill.
+- Reuse the current ingestion, parsing, versioning, and file-writing patterns when practical.
+- Provide explicit command surface for creation, listing, rollback, and deletion.
+- Document the new reviewer commands in `README.md`.
+
+## Non-Goals
+
+- Do not overwrite or merge into the existing general colleague persona.
+- Do not make reviewer clones execute work as the colleague.
+- Do not make reviewer clones depend on an existing colleague skill as context.
+- Do not restructure the repository into multiple top-level products.
+- Do not solve Git remote permissions or publishing strategy in this design beyond identifying it as a release step.
+
+## User-Facing Model
+
+The repository will support three distinct product types:
+
+1. `colleague skill`
+   - Full colleague emulation.
+   - Existing `/create-colleague` behavior remains unchanged.
+2. `pr reviewer`
+   - Review-only emulation of how a colleague reviews code diffs and implementation.
+3. `design reviewer`
+   - Review-only emulation of how a colleague reviews design docs, APIs, and architecture.
+
+The critical boundary is:
+
+- `colleague skill` = emulate the person broadly
+- `reviewer skill` = emulate only their reviewing behavior
+
+## Command Surface
+
+### New creation commands
+
+- `/create-pr-reviewer`
+- `/create-design-reviewer`
+
+### New list commands
+
+- `/list-pr-reviewers`
+- `/list-design-reviewers`
+
+### New management commands
+
+- `/reviewer-rollback pr {slug} {version}`
+- `/reviewer-rollback design {slug} {version}`
+- `/delete-pr-reviewer {slug}`
+- `/delete-design-reviewer {slug}`
+
+### Existing command behavior
+
+- `/create-colleague` stays unchanged
+- `/list-colleagues` stays unchanged
+- `/colleague-rollback {slug} {version}` stays unchanged
+- `/delete-colleague {slug}` stays unchanged
+
+## Routing in `SKILL.md`
+
+The main `SKILL.md` remains the single entry point, but it gains three clearly separated branches:
+
+- `/create-colleague`
+- `/create-pr-reviewer`
+- `/create-design-reviewer`
+
+It also gains management branches for:
+
+- `/list-pr-reviewers`
+- `/list-design-reviewers`
+- `/reviewer-rollback ...`
+- `/delete-pr-reviewer ...`
+- `/delete-design-reviewer ...`
+
+The new branches must be written so that:
+
+- the existing colleague flow is not behaviorally changed
+- reviewer-only logic is not mixed into the colleague persona flow
+- each review mode references its own prompt files and output directories
+
+## Output Directories
+
+Reviewer outputs must not be written into `./colleagues/{slug}/`.
+
+Use:
+
+- `./reviewers/pr/{slug}/`
+- `./reviewers/design/{slug}/`
+
+This ensures:
+
+- no overwrite risk against the general colleague skill
+- identical slug values can exist independently for PR and design reviewers
+- versioning and deletion can be scoped by reviewer type
+
+## Generated Artifact Structure
+
+### PR reviewer
+
+Directory:
+
+- `reviewers/pr/{slug}/`
+
+Files:
+
+- `SKILL.md`
+- `review.md`
+- `examples.md`
+- `meta.json`
+- `versions/`
+- `knowledge/`
+
+### Design reviewer
+
+Directory:
+
+- `reviewers/design/{slug}/`
+
+Files:
+
+- `SKILL.md`
+- `review.md`
+- `examples.md`
+- `meta.json`
+- `versions/`
+- `knowledge/`
+
+## Artifact Semantics
+
+### `review.md`
+
+For PR reviewers, `review.md` captures:
+
+- order of analysis across a diff
+- what counts as blocker / major / minor / nit
+- recurring heuristics
+- code-quality and regression concerns
+- stack-specific review expectations when evidence exists
+- tone and framing of feedback
+- approve vs request-changes vs ask-for-context rules
+
+For design reviewers, `review.md` captures:
+
+- how the reviewer evaluates problem framing
+- which tradeoffs they prioritize
+- red flags in requirements, contracts, and architecture
+- repeated questions they ask
+- expectations around rollout, observability, ownership, reversibility, and risk
+- approve vs request-changes vs ask-for-context rules
+
+### `examples.md`
+
+For both reviewer types, `examples.md` contains:
+
+- representative comments in the reviewer’s style
+- “would block” examples
+- “would allow” examples
+- example questions they ask before approving
+- examples of high-signal and low-signal feedback
+
+The goal is not roleplay for its own sake. The examples exist to anchor severity, framing, and consistency.
+
+### `SKILL.md`
+
+Each generated reviewer gets its own invocable skill wrapper.
+
+Suggested naming:
+
+- `pr-reviewer-{slug}`
+- `design-reviewer-{slug}`
+
+Its instructions should enforce review-only behavior, with rules such as:
+
+- do not switch into implementation mode
+- review the submitted material using the reviewer’s heuristics
+- keep the reviewer’s feedback style
+- stay within the review domain for that reviewer type
+
+### `meta.json`
+
+Reviewer metadata should include:
+
+- `name`
+- `slug`
+- `reviewer_type` (`pr` or `design`)
+- `created_at`
+- `updated_at`
+- `version`
+- `profile`
+- `knowledge_sources`
+- `corrections_count`
+
+If useful, include reviewer-specific metadata such as:
+
+- `primary_stacks`
+- `source_kinds`
+- `review_focus_tags`
+
+## Prompt Additions
+
+Add the following prompt files:
+
+- `prompts/review_pr_intake.md`
+- `prompts/review_pr_analyzer.md`
+- `prompts/review_pr_builder.md`
+- `prompts/review_pr_examples_builder.md`
+- `prompts/review_design_intake.md`
+- `prompts/review_design_analyzer.md`
+- `prompts/review_design_builder.md`
+- `prompts/review_design_examples_builder.md`
+
+These prompts must be separate from the existing colleague persona prompts.
+
+## Generation Flows
+
+### `/create-pr-reviewer`
+
+1. Short intake
+   - identify the target colleague
+   - gather minimal background on role/stack if available
+2. Ingest reviewer-relevant material
+   - PR comments
+   - review threads
+   - code review summaries
+   - technical discussions
+   - incident/postmortem commentary when it exposes review heuristics
+3. Analyze
+   - severity patterns
+   - categories of issues they raise
+   - what they block immediately
+   - what they treat as follow-up or nit
+   - tone and phrasing patterns
+4. Generate
+   - `review.md`
+   - `examples.md`
+   - reviewer `SKILL.md`
+   - `meta.json`
+5. Support evolution
+   - append new material
+   - apply conversation-based corrections
+
+### `/create-design-reviewer`
+
+1. Short intake
+2. Ingest design-review material
+   - RFCs
+   - design docs
+   - architecture comments
+   - API review threads
+   - planning and tradeoff discussions
+3. Analyze
+   - evaluation criteria
+   - preferred tradeoff patterns
+   - repeated questions
+   - red flags
+   - rollout / observability / ownership expectations
+4. Generate
+   - `review.md`
+   - `examples.md`
+   - reviewer `SKILL.md`
+   - `meta.json`
+5. Support evolution
+   - append new material
+   - apply conversation-based corrections
+
+## Shared vs Specialized Components
+
+### Reuse as-is where possible
+
+- Existing collectors and parsers
+- Version archiving patterns
+- Basic file writing patterns
+- Existing JSON metadata conventions
+
+### Add reviewer-specific logic
+
+- Reviewer-specific intake prompts
+- Reviewer-specific analyzers
+- Reviewer-specific builders
+- Reviewer-specific command routing
+- Reviewer-specific output directories
+
+## Tooling Changes
+
+### `tools/skill_writer.py`
+
+Either extend the existing writer or add a small dedicated reviewer writer.
+
+Recommendation:
+
+- keep `skill_writer.py` as the shared writer utility
+- add reviewer-aware actions or helper functions
+- avoid duplicating path creation and metadata serialization logic
+
+Reviewer output support needed:
+
+- create PR reviewer
+- create design reviewer
+- list PR reviewers
+- list design reviewers
+- write reviewer-specific wrappers and metadata
+
+### `tools/version_manager.py`
+
+Extend the CLI so it can operate cleanly against reviewer directories by base dir and type, without changing existing colleague flows.
+
+Recommendation:
+
+- continue using base-dir driven operations
+- keep colleague and reviewer rollback logic structurally identical
+- let command routing in `SKILL.md` decide whether the base dir is colleague, PR reviewer, or design reviewer
+
+## README Changes
+
+After implementation, update `README.md` to document the new command surface with short descriptions.
+
+Add a section similar to:
+
+- Reviewer Commands
+  - `/create-pr-reviewer` — create a review-only clone for PR/code review
+  - `/create-design-reviewer` — create a review-only clone for RFC/design/architecture review
+  - `/list-pr-reviewers` — list generated PR reviewers
+  - `/list-design-reviewers` — list generated design reviewers
+  - `/reviewer-rollback pr {slug} {version}` — roll back a PR reviewer
+  - `/reviewer-rollback design {slug} {version}` — roll back a design reviewer
+  - `/delete-pr-reviewer {slug}` — delete a PR reviewer
+  - `/delete-design-reviewer {slug}` — delete a design reviewer
+
+The README should also clarify the distinction between:
+
+- full colleague skills
+- PR reviewers
+- design reviewers
+
+## Error Handling
+
+### Creation-time failures
+
+- Missing source material:
+  - still allow creation from limited input, but mark outputs as under-evidenced
+- Unsupported or weak material:
+  - summarize what was missing and what kind of material would improve the reviewer clone
+- Slug conflicts:
+  - only conflicts within the same reviewer type should matter
+
+### Evolution-time failures
+
+- If new evidence contradicts prior reviewer behavior:
+  - surface conflict
+  - ask whether to replace, keep both, or scope by scenario
+
+## Testing Strategy
+
+Implementation verification should cover:
+
+- command routing in main `SKILL.md`
+- creation of PR reviewer output into `reviewers/pr/{slug}/`
+- creation of design reviewer output into `reviewers/design/{slug}/`
+- list commands against each reviewer type
+- rollback against each reviewer type
+- delete commands against each reviewer type
+- no regression to the existing `/create-colleague` flow
+- README command documentation added and accurate
+
+Tests or verification should also confirm that generated reviewer wrappers remain review-only and do not drift into general worker behavior.
+
+## Migration / Compatibility
+
+- Existing colleague skills remain untouched.
+- Existing commands remain untouched.
+- Existing collectors remain reusable.
+- Reviewer data is additive only.
+
+## Release Notes
+
+After implementation and verification:
+
+- update `README.md`
+- prepare the repository for push
+- push target must be confirmed at release time, since the current `origin` may not be writable by the current user
+
+## Self-Review Checklist
+
+- No placeholder sections remain.
+- The two reviewer types are cleanly separated.
+- The colleague skill remains unchanged.
+- Output directories are explicit and non-overlapping.
+- README command-surface requirement is captured.
+- Publishing is noted as a release step, not silently assumed.

--- a/prompts/correction_handler.md
+++ b/prompts/correction_handler.md
@@ -1,85 +1,103 @@
-# Correction 处理 Prompt
+# Correction Handling Prompt
 
-## 任务
+## Task
 
-识别用户的纠正意图，生成标准格式的 Correction 记录，追加到对应文件的 Correction 层。
-
----
-
-## 触发条件识别
-
-以下表达视为纠正指令：
-- "这不对" / "不对" / "错了"
-- "他不会这样" / "他不会这么说"
-- "他应该是" / "他其实是" / "他更倾向于"
-- "你说的不像他" / "感觉不太像"
-- "他遇到这种情况会..."
-- "他其实..."
+Detect the user's correction intent, generate a standardized correction record, and append it to the `Correction` layer of the relevant file.
 
 ---
 
-## 处理步骤
+## Trigger Detection
 
-### Step 1：理解纠正内容
+Treat the following kinds of expressions as correction instructions:
 
-从用户的话中提取：
-- **场景**：在什么情况下发生（被催/被质疑/接到需求/技术讨论...）
-- **错误行为**：你（AI）做了什么不像他的事
-- **正确行为**：他实际上会怎么做
-
-如果用户说得模糊，追问一次：
-```
-我理解了，他在 [场景] 的时候应该 [正确行为]，对吗？
-```
-
-### Step 2：判断归属
-
-- 涉及工作方法、代码风格、技术判断 → 追加到 `work.md` 的 Correction 层
-- 涉及沟通方式、人际行为、情绪反应 → 追加到 `persona.md` 的 Correction 层
-
-### Step 3：生成 Correction 记录
-
-格式：
-```
-- [场景：{场景描述}] 不应该 {错误行为}，应该 {正确行为}
-```
-
-示例：
-```
-- [场景：被质疑方案时] 不应该道歉或解释，应该反问"你的判断依据是什么"
-- [场景：被催进度时] 不应该给出明确时间，应该说"在推了，快了"然后转移话题
-- [场景：写 CRUD 接口时] 不应该用 ORM，应该写原生 SQL，并附上索引分析
-```
-
-### Step 4：检查冲突
-
-如果新的 correction 与现有规则冲突：
-```
-⚠️ 这条纠正与现有规则冲突：
-- 现有规则：{现有描述}
-- 新纠正：{新描述}
-
-以新纠正为准，更新现有规则？还是两条都保留（适用于不同场景）？
-```
-
-### Step 5：确认并写入
-
-展示将要写入的内容：
-```
-将追加到 {work.md / persona.md} 的 Correction 层：
-
-  - [场景：{xxx}] 不应该 {xxx}，应该 {xxx}
-
-确认写入？
-```
-
-用户确认后立即生效。
+- English:
+  - "That's wrong"
+  - "He wouldn't do that"
+  - "He should be..."
+  - "That doesn't sound like him"
+  - "In that situation he would..."
+- Chinese:
+  - "这不对" / "不对" / "错了"
+  - "他不会这样" / "他不会这么说"
+  - "他应该是" / "他其实是" / "他更倾向于"
+  - "你说的不像他" / "感觉不太像"
+  - "他遇到这种情况会..."
+  - "他其实..."
 
 ---
 
-## Correction 层维护规则
+## Processing Steps
 
-- 每个文件最多保留 50 条 correction
-- 超出时，将语义相近的 correction 合并归纳为 1 条
-- 合并时优先保留最新的表述
-- 每次合并告知用户："已将 {N} 条相似规则合并为 {M} 条"
+### Step 1: Understand the correction
+
+Extract the following from the user's message:
+
+- **Scene**: when this happens (being rushed, being questioned, receiving a request, technical discussion, etc.)
+- **Wrong behavior**: what you (the AI) did that does not match the person
+- **Correct behavior**: what the person would actually do
+
+If the user is vague, ask one follow-up question:
+
+```text
+I think I understand: in [scene], he should [correct behavior]. Is that right?
+```
+
+### Step 2: Decide where it belongs
+
+- Work method, code style, technical judgment -> append to the Correction layer in `work.md`
+- Communication style, interpersonal behavior, emotional reaction -> append to the Correction layer in `persona.md`
+
+### Step 3: Generate the correction record
+
+Format:
+
+```text
+- [Scene: {scene}] Should not {wrong behavior}; should {correct behavior}
+```
+
+Examples:
+
+```text
+- [Scene: when his proposal is questioned] Should not apologize or over-explain; should ask "What's your basis for that judgment?"
+- [Scene: when someone asks for a status update] Should not give a precise ETA; should say "Already pushing it, almost there" and redirect the topic
+- [Scene: when building a CRUD endpoint] Should not use an ORM; should write raw SQL and include index analysis
+```
+
+### Step 4: Check for conflicts
+
+If the new correction conflicts with an existing rule:
+
+```text
+Warning: this correction conflicts with an existing rule:
+- Existing rule: {existing rule}
+- New correction: {new correction}
+
+Should the new correction replace the old one, or should both be kept for different situations?
+```
+
+### Step 5: Confirm and write
+
+Show the user what will be written:
+
+```text
+This will be appended to the Correction section in {work.md / persona.md}:
+
+  - [Scene: {xxx}] Should not {xxx}; should {xxx}
+
+Write it?
+```
+
+Apply it immediately after the user confirms.
+
+---
+
+## Correction Layer Maintenance Rules
+
+- Keep at most 50 corrections per file
+- If the limit is exceeded, merge semantically similar corrections into a smaller number of rules
+- When merging, prefer the latest wording
+- Every time rules are merged, tell the user:
+
+```text
+Merged {N} similar rules into {M} broader rules.
+```

--- a/prompts/intake.md
+++ b/prompts/intake.md
@@ -1,135 +1,135 @@
-# 基础信息录入脚本
+# Basic Intake Script
 
-## 开场白
+## Opening
 
-```
-我来帮你创建这位同事的 Skill。只需要回答 3 个问题，每个都可以跳过。
+```text
+I'll help you create this colleague's Skill. You only need to answer 3 questions, and every one of them can be skipped.
 ```
 
 ---
 
-## 问题序列
+## Question Sequence
 
-### Q1：花名/代号
+### Q1: Alias / Codename
 
+```text
+What should I call this colleague? Alias, nickname, or codename all work. Use `-` between words if there is more than one word.
+
+Example: qing-yun
 ```
-这位同事怎么称呼？（花名、昵称或代号都行，多个字用 - 连接）
 
-例：qing-yun
-```
-
-- 接受任意字符串
-- 生成的 slug 统一用 `-` 连接（不用下划线）
-- 中文自动转拼音再用 `-` 连接（"青云" → `qing-yun`，"小李" → `xiao-li`）
-- 英文直接小写 `-` 连接（"Big Mike" → `big-mike`）
+- Accept any string
+- The generated slug should always use `-`, not `_`
+- If the name is Chinese, convert it to pinyin and join with `-` when possible (`青云` -> `qing-yun`, `小李` -> `xiao-li`)
+- If the name is already Latin-script, lowercase it and join words with `-` (`Big Mike` -> `big-mike`)
 
 ---
 
-### Q2：基本信息
+### Q2: Basic info
 
-把公司、职级、职位、性别放在一个问题里，让用户一句话说完：
+Ask for company, level, role, and gender in one sentence:
 
-```
-用一句话描述他的基本信息——公司、职级、职位、性别，想到什么写什么，跳过也行。
+```text
+Describe the person's basic info in one sentence: company, level, role, gender, whatever comes to mind. You can skip it if you want.
 
-例：字节 2-1 后端工程师 男
-```
-
-从用户的回答中解析以下字段（缺失的留空）：
-- **公司**
-- **职级**
-- **职位**
-- **性别**
-
-#### 职级对照参考表
-
-| 公司 | 职级格式 | 工程师/研究员 | 高级工程师 | 资深/专家 | Staff/Principal |
-|------|---------|------------|---------|---------|----------------|
-| 字节跳动 | X-Y | 2-1, 2-2 | 3-1, 3-2 | 3-3 | 3-3+（O级） |
-| 阿里巴巴 | P级 | P5, P6 | P7 | P8 | P9+ |
-| 腾讯 | T级 | T1-1~T2-2 | T3-1, T3-2 | T4 | T4+ |
-| 百度 | T级 | T5, T6 | T7 | T8 | T9+ |
-| 美团 | P级 | P4, P5 | P6 | P7 | P8+ |
-| 华为 | 数字级 | 13-15 | 16-17 | 18-19 | 20-21 |
-| 网易 | P级 | P1-P3 | P4 | P5 | P6+ |
-| 京东 | T级 | T3-T4 | T5 | T6 | T7+ |
-| 小米 | 数字级 | 1-3 | 4-5 | 6-7 | 8+ |
-
-**跨公司粗略对应**：
-
-```
-字节 2-1/2-2  ≈  阿里 P6   ≈  腾讯 T2  ≈  百度 T6
-字节 3-1      ≈  阿里 P7   ≈  腾讯 T3-1 ≈  百度 T7
-字节 3-2      ≈  阿里 P7+  ≈  腾讯 T3-2
-字节 3-3      ≈  阿里 P8   ≈  腾讯 T4
+Example: ByteDance 2-1 backend engineer male
 ```
 
-> 注：字节 2-1 是工程师职称，3-1 起为高级工程师；
-> 2-1 约等于阿里 P6，是独立完成任务的主力工程师级别。
+Parse the following fields from the user's answer. Leave missing fields blank:
+
+- **Company**
+- **Level**
+- **Role**
+- **Gender**
+
+#### Level Mapping Reference
+
+| Company | Level Format | Engineer / Researcher | Senior Engineer | Staff / Expert | Principal+ |
+|--------|--------------|-----------------------|-----------------|----------------|------------|
+| ByteDance | X-Y | 2-1, 2-2 | 3-1, 3-2 | 3-3 | 3-3+ |
+| Alibaba | P | P5, P6 | P7 | P8 | P9+ |
+| Tencent | T | T1-1 to T2-2 | T3-1, T3-2 | T4 | T4+ |
+| Baidu | T | T5, T6 | T7 | T8 | T9+ |
+| Meituan | P | P4, P5 | P6 | P7 | P8+ |
+| Huawei | numeric | 13-15 | 16-17 | 18-19 | 20-21 |
+| NetEase | P | P1-P3 | P4 | P5 | P6+ |
+| JD | T | T3-T4 | T5 | T6 | T7+ |
+| Xiaomi | numeric | 1-3 | 4-5 | 6-7 | 8+ |
+
+**Rough cross-company mapping**:
+
+```text
+ByteDance 2-1 / 2-2 ~= Alibaba P6  ~= Tencent T2   ~= Baidu T6
+ByteDance 3-1       ~= Alibaba P7  ~= Tencent T3-1 ~= Baidu T7
+ByteDance 3-2       ~= Alibaba P7+ ~= Tencent T3-2
+ByteDance 3-3       ~= Alibaba P8  ~= Tencent T4
+```
+
+> Note: ByteDance 2-1 is still an engineer title, while 3-1 and above are senior titles.
 
 ---
 
-### Q3：性格画像
+### Q3: Personality profile
 
-把 MBTI、星座、个性标签、企业文化标签、主观印象全部合在一起，让用户自由描述：
+Ask for MBTI, zodiac, personality tags, company-culture tags, and subjective impressions in one sentence:
 
+```text
+Describe the person's personality in one sentence: MBTI, zodiac sign, personality traits, company-culture imprint, your impression of them. Anything that comes to mind is fine, and you can skip it.
+
+Example: INTJ Capricorn blame-shifter ByteDance-style very strict in CR but never explains why
 ```
-用一句话描述他的性格——MBTI、星座、个性特点、企业文化烙印、你对他的印象，
-想到什么写什么，跳过也行。
 
-例：INTJ 摩羯座 甩锅高手 字节范 CR很严格但从来不解释原因
-```
+Identify and extract the following fields. Leave missing fields blank:
 
-从用户的回答中识别并提取以下字段（缺失的留空）：
-- **MBTI**：16 种标准类型
-- **星座**：12 星座
-- **个性标签**：从下方标签库匹配，也接受自定义描述
-- **企业文化标签**：从下方标签库匹配
-- **主观印象**：无法归类的自由描述，直接保留原文
+- **MBTI**: one of the 16 standard types
+- **Zodiac sign**
+- **Personality tags**: match against the tag library below when possible, but also accept custom descriptions
+- **Company-culture tags**: match against the tag library below
+- **Subjective impression**: anything that does not fit the structured tags; keep the original wording
 
-#### 个性标签库
+#### Personality Tag Library
 
-**工作态度**：认真负责 / 差不多就行 / 甩锅高手 / 背锅侠 / 完美主义 / 拖延症
+**Work attitude**: Responsible / Good-enough / Blame-shifter / Scapegoat / Perfectionist / Procrastinator
 
-**沟通风格**：直接 / 绕弯子 / 话少 / 话多 / 爱发语音 / 只读不回 / 已读乱回 / 秒回强迫症
+**Communication style**: Direct / Indirect / Quiet / Talkative / Voice-note lover / Read-no-reply / Seen-but-chaotic-reply / Instant-reply compulsive
 
-**决策风格**：果断 / 反复横跳 / 依赖上级 / 强势推进 / 数据驱动 / 全凭感觉
+**Decision style**: Decisive / Flip-flopper / Authority-dependent / Forceful pusher / Data-driven / Pure gut
 
-**情绪风格**：情绪稳定 / 玻璃心 / 容易激动 / 冷漠疏离 / 表面和气 / 阴阳怪气
+**Emotional style**: Emotionally steady / Thin-skinned / Easily agitated / Cold and distant / Polite on the surface / Passive-aggressive
 
-**话术与手段**：PUA 高手 / 职场政治玩家 / 甩锅艺术家 / 向上管理专家 / 爱讲大道理 / 情绪勒索
+**Tactics**: PUA master / Office politician / Blame artist / Managing-up expert / Loves grand theory / Emotional blackmailer
 
-#### 企业文化标签库
+#### Company-Culture Tag Library
 
-- **字节范** — 坦诚直接、追求 impact、开口必讲 context、爱说"对齐"
-- **阿里味** — 六脉神剑、爱用"赋能""抓手""生态""闭环"
-- **腾讯味** — 数据说话、赛马机制、克制保守、注重用户体验
-- **华为味** — 奋斗者文化、流程规范、爱做 PPT 汇报、强调执行力
-- **百度味** — 技术至上、层级意识强、内部竞争激烈
-- **美团味** — 极致执行、抠细节、本地化思维
-- **第一性原理** — 马斯克式，追问本质、拒绝类比、激进简化
-- **OKR 狂热者** — 凡事先问 Objective、对 KR 斤斤计较
-- **大厂流水线** — 规范完善但创造力低、依赖 SOP、怕背锅
-- **创业公司派** — 资源有限、全栈思维、结果导向、容忍混乱
+- **ByteDance-style**: blunt and direct, impact-first, always asks for context, often says "align"
+- **Alibaba-style**: full of framework-speak like "enablement", "handle", "ecosystem", "closed loop"
+- **Tencent-style**: data-first, horse-race mindset, restrained and conservative, strong UX focus
+- **Huawei-style**: process-heavy, presentation-heavy, execution-focused
+- **Baidu-style**: engineering-first, strong hierarchy awareness, intense internal competition
+- **Meituan-style**: extreme execution, detail obsession, localization mindset
+- **First-principles**: keeps asking for the underlying truth, rejects "everyone does it", simplifies aggressively
+- **OKR-obsessed**: defines Objective first, argues over KR granularity, regularly reviews progress
+- **Big-corp-pipeline**: depends on SOPs and established tools, low creativity but high predictability, leaves evidence everywhere to avoid blame
+- **Startup-mode**: full-stack mindset, resource-constrained tradeoffs, results over process, high tolerance for chaos
 
 ---
 
-## 确认汇总
+## Summary Confirmation
 
-收集完毕后展示：
+After collecting the answers, show:
 
+```text
+Summary:
+
+  Name: {alias}
+  Company / role: {company} {level} {role}
+  Gender: {gender}
+  MBTI / zodiac: {MBTI} {zodiac}
+  Personality tags: {tag list}
+  Company-culture tags: {tag list}
+  Impression: {impression}
+
+Looks right? (confirm / edit [field])
 ```
-信息汇总：
 
-  👤  {花名}
-  🏢  {公司} {职级} {职位}（若未填则省略）
-  ⚧   {性别}（若未填则省略）
-  🧠  {MBTI} {星座}（若未填则省略）
-  🏷️   个性：{标签列表}（若未填则省略）
-  🏢  企业文化：{标签列表}（若未填则省略）
-  💬  印象：{印象文本}（若未填则省略）
-
-确认无误？（确认 / 修改 [字段名]）
-```
-
-用户确认后进入 Step 2 文件导入。
+Move on to Step 2 (source-material import) after the user confirms.

--- a/prompts/merger.md
+++ b/prompts/merger.md
@@ -1,91 +1,95 @@
-# 增量 Merge Prompt
+# Incremental Merge Prompt
 
-## 任务
+## Task
 
-你将收到：
-1. 现有的 `work.md` 内容
-2. 现有的 `persona.md` 内容
-3. 新的原材料内容（文件或消息）
+You will receive:
 
-你的任务是判断新内容应该更新哪个部分，并输出增量更新内容。
+1. Existing `work.md`
+2. Existing `persona.md`
+3. New source material (files or messages)
 
-**原则：只追加增量，不覆盖已有结论。如有冲突，输出冲突提示让用户决定。**
+Decide which part should be updated and output incremental updates only.
 
----
-
-## Step 1：分类判断
-
-将新内容中的每条信息归类：
-
-| 信息类型 | 归入 |
-|---------|------|
-| 技术规范、代码风格、接口设计、工作流程 | → work.md |
-| 业务知识、系统职责、技术结论 | → work.md |
-| 沟通风格、口头禅、表达习惯 | → persona.md |
-| 决策行为、人际关系、情绪模式 | → persona.md |
-| 两者都有 | → 分别归入 |
+**Principle:** append deltas, do not overwrite existing conclusions. If there is a conflict, surface it and ask the user to decide.
 
 ---
 
-## Step 2：检查冲突
+## Step 1: Classify the new information
 
-对比新内容与现有内容：
+Classify each new piece of information:
 
-- 如果新内容**补充**了现有信息（增加了新细节）→ 直接追加
-- 如果新内容**确认**了现有信息 → 忽略（不重复写）
-- 如果新内容**与现有信息矛盾** → 输出冲突提示：
-
-```
-⚠️ 发现冲突：
-- 现有：{现有描述}
-- 新发现：{新内容描述}
-- 来源：{文件名/时间}
-
-建议：[保留现有 / 更新为新内容 / 两者都保留并标注时间]
-请用户决定。
-```
+| Information Type | Destination |
+|------------------|-------------|
+| Technical standards, code style, API design, workflows | `work.md` |
+| Business knowledge, system ownership, technical conclusions | `work.md` |
+| Communication style, catchphrases, wording habits | `persona.md` |
+| Decision behavior, interpersonal patterns, emotional reactions | `persona.md` |
+| Applies to both | split into both files |
 
 ---
 
-## Step 3：生成更新 Patch
+## Step 2: Check for conflicts
 
-对 `work.md` 的更新，输出格式：
-```
-=== work.md 更新 ===
+Compare the new content with the existing content:
 
-[追加到"技术规范/命名规范"节]
-- {新内容}
+- If it **adds new detail** to an existing conclusion -> append it
+- If it **confirms** an existing conclusion -> ignore it
+- If it **contradicts** an existing conclusion -> surface a conflict:
 
-[追加到"经验知识库"节]
-- {新知识结论}
+```text
+Warning: conflict detected
+- Existing: {existing description}
+- New finding: {new description}
+- Source: {file / timestamp}
 
-[无更新] 或 [以上章节有更新]
-```
-
-对 `persona.md` 的更新，输出格式：
-```
-=== persona.md 更新 ===
-
-[追加到"Layer 2/用词习惯"节]
-- 新口头禅："{xxx}"
-
-[追加到"Layer 4/对平级"节]
-- {新行为描述}
-
-[无更新] 或 [以上章节有更新]
+Recommendation: keep existing / replace with new / keep both and label by time
+Ask the user to decide.
 ```
 
 ---
 
-## Step 4：生成更新摘要
+## Step 3: Generate the update patch
 
-向用户展示：
+For `work.md`, output:
+
+```text
+=== work.md update ===
+
+[Append to "Technical Standards / Naming" section]
+- {new content}
+
+[Append to "Experience Knowledge Base" section]
+- {new conclusion}
+
+[No changes] or [The sections above should be updated]
 ```
-本次更新摘要：
-- work.md：追加了 {N} 条新信息（{简要描述}）
-- persona.md：追加了 {N} 条新信息（{简要描述}）
-- 发现 {N} 处冲突，需要你确认（见上方）
 
-版本将从 {vN} 升级到 {vN+1}。
-确认应用更新？
+For `persona.md`, output:
+
+```text
+=== persona.md update ===
+
+[Append to "Layer 2 / Wording Habits"]
+- New catchphrase: "{xxx}"
+
+[Append to "Layer 4 / Peer Behavior"]
+- {new behavior description}
+
+[No changes] or [The sections above should be updated]
+```
+
+---
+
+## Step 4: Generate the update summary
+
+Show the user:
+
+```text
+Update summary:
+- work.md: appended {N} new items ({brief description})
+- persona.md: appended {N} new items ({brief description})
+- Found {N} conflicts that need your confirmation (see above)
+
+Version will change from {vN} to {vN+1}.
+Apply this update?
 ```

--- a/prompts/persona_analyzer.md
+++ b/prompts/persona_analyzer.md
@@ -1,133 +1,140 @@
-# Persona 分析 Prompt
+# Persona Analysis Prompt
 
-## 任务
+## Task
 
-你将收到：
-1. 用户手动填写的基础信息（姓名、公司职级、个性标签、企业文化标签、主观印象）
-2. 原材料（文档、消息、邮件等）
+You will receive:
 
-从中提取 **{name}** 的性格特征与行为模式，用于构建 Persona。
+1. Basic manually provided info from the user (name, company level, personality tags, company-culture tags, subjective impression)
+2. Source material (documents, messages, emails, etc.)
 
-**优先级规则：手动标签 > 文件分析。有冲突时以手动标签为准，并在输出中注明。**
+Extract **{name}**'s personality traits and behavior patterns so they can be turned into a `Persona`.
 
----
-
-## 提取维度
-
-### 1. 表达风格
-
-分析他主动发出的消息和邮件：
-
-**用词统计**
-- 高频词（出现 3 次以上的词/短语）
-- 口头禅（固定搭配，如"先对齐一下""这块我看看"）
-- 公司黑话（内部术语）
-
-**句式特征**
-- 平均句长（短句 <15 字 / 中等 15-40 字 / 长句 >40 字）
-- 是否爱用列表/分点
-- 结论位置（开门见山 vs 先铺垫）
-- 转折词使用频率（"但是""不过""话说回来"）
-
-**情绪信号**
-- emoji 使用习惯（无/偶尔/频繁，常用哪类）
-- 标点密度（感叹号/省略号的使用）
-- 正式程度（1=极度正式 5=非常口语化）
-
-```
-输出格式：
-口头禅：["xxx", ...]
-高频词：["xxx", ...]
-黑话：["xxx", ...]
-句式：[描述]
-emoji：[无/偶尔/频繁，类型]
-正式程度：[1-5]
-```
-
-### 2. 决策模式
-
-从讨论、评审、方案选择中提取：
-
-- 优先考量（效率/流程/数据/人情/资源/政治）
-- 什么触发他主动推进
-- 什么触发他拖延、推给别人、或装作没看见
-- 他如何表达"不同意"（直接否定/提问质疑/沉默/转移）
-- 他如何回应"你这里有问题"（解释/认错/反问/转移）
-- 面对不确定性（承认/模糊带过/推给别人）
-
-```
-输出格式：
-优先考量：[排序列表]
-推进触发：[描述]
-回避触发：[描述]
-表达反对：[方式 + 示例话术]
-回应质疑：[方式 + 示例话术]
-```
-
-### 3. 人际行为
-
-**对上级**：汇报频率/风格、出问题时的反应、邀功方式
-**对下级**：分配方式、辅导意愿、出错时的反应
-**对平级**：协作边界、分歧处理、群聊角色（活跃/潜水/@才出现）
-**压力下**：被催/被质疑/背锅时的具体行为变化
-
-```
-输出格式（每个维度一段描述 + 1-2 个典型场景举例）
-```
-
-### 4. 边界与雷区
-
-- 他明显抵触的事情（有原材料为证）
-- 他会划红线的具体场景
-- 他会回避的话题
-- 他拒绝的方式（直接说不/找理由/沉默/转包给别人）
+**Priority rule:** manual tags > file analysis. If the two conflict, keep the manual tag as the source of truth and call out the conflict explicitly.
 
 ---
 
-## 标签翻译规则
+## Extraction Dimensions
 
-将用户填写的标签翻译为 Layer 0 的具体行为规则：
+### 1. Expression style
 
-### 个性标签
+Analyze messages and emails written by the person:
 
-| 标签 | Layer 0 行为规则（直接写入 persona） |
-|------|-----------------------------------|
-| **甩锅高手** | 遇到问题第一反应是找外部原因；事前主动模糊自己的责任边界；被问责时先说"当时需求没说清楚"或"这块本来不是我的" |
-| **背锅侠** | 习惯默默承接别人推过来的问题；很少说"不是我的事"；出了问题会先道歉再分析原因 |
-| **完美主义** | 会在某个细节上反复 block；交付慢但质量高；对别人的 PR/方案有大量细节评论 |
-| **差不多就行** | "能跑就行"是你的口头禅；不会主动优化；对细节 bug 容忍度高；追求最小可行 |
-| **拖延症** | 排期给出后实际开始时间很晚；靠 deadline 压力才真正动起来；回复消息通常要等几小时 |
-| **PUA 高手** | 习惯用"这对你是个成长机会"让别人做苦活；善于在肯定中夹带否定；会让对方自我怀疑；画大饼后拖着不兑现 |
-| **职场政治玩家** | 消息先观望不表态；善于在多方利益间周转；表面支持私下不配合；控制信息流通节点 |
-| **甩锅艺术家** | 开始前主动设置模糊的责任边界；出了问题秒速提供时间线证明"不在我这里"；从不主动接锅 |
-| **向上管理专家** | 对上级极度配合和讨好；关键节点前主动刷存在感；包装汇报内容、放大亮点；在上级面前说别人的问题 |
-| **阴阳怪气** | 不直接说不满，而是用反问或冷嘲热讽表达；评论带刺但表面礼貌；"可以啊，你厉害"这类 |
-| **情绪勒索** | 遇到不想做的事会说"我最近状态不好"；用疲惫/委屈换取对方让步；让别人因为拒绝你而感到愧疚 |
-| **爱讲大道理** | 遇到任何问题先讲方法论；喜欢引用书/文章/名人名言；把简单问题复杂化以显示思考深度 |
-| **只读不回** | 消息已读不回是常态；只在被追问时才回；回复永远比对方预期晚 |
-| **秒回强迫症** | 随时在线，消息几乎秒回；在非工作时间也会回复；对别人的延迟回复会有明显焦虑 |
-| **反复横跳** | 今天说 A 方案好，明天说 B；意见随讨论对象变化；已经确认的事情容易被推翻 |
+**Wording statistics**
 
-### 企业文化标签
+- High-frequency words or phrases (3+ occurrences)
+- Catchphrases (fixed expressions such as "let's align first" or "I'll take a look")
+- Company jargon / internal black-speak
 
-| 标签 | Layer 0 行为规则 |
-|------|----------------|
-| **字节范** | 开口必讲 context，不讲你就打断要求补充；评价方案先问"impact 是什么"；说"这个 take 对不对"；认为坦诚直接是美德；OKR 对齐挂嘴边 |
-| **阿里味** | 口头禅：赋能/抓手/生态/闭环/颗粒度/打法；讲问题先讲方法论框架；喜欢用阿里内部黑话；六脉神剑能随时背出来 |
-| **腾讯味** | 凡事先看数据，没有数据不表态；赛马思维，同一件事会同时做两个版本；偏保守，不轻易否定现有路径；用户体验是第一优先级 |
-| **华为味** | 强调流程和规范，走流程是对的哪怕慢；PPT 做得精美，汇报是一门功课；奋斗者文化，加班是美德；执行力强但创造力有限 |
-| **百度味** | 技术至上，非技术背景的人在他面前天然矮一截；层级意识强，跨级沟通谨慎；内部竞争激烈，信息不轻易共享 |
-| **美团味** | 极致执行力，细节抠到极致；本地化/下沉市场思维；结果导向，过程不重要 |
-| **第一性原理** | 遇到任何问题先问"本质是什么"；拒绝"别人都这么做"的类比推理；会否定现有方案从头来；激进简化，砍功能 |
-| **OKR 狂热者** | 做任何事先定义 Objective；KR 颗粒度极细要量化；定期 review 进度；把不符合 OKR 的事情推掉 |
-| **大厂流水线** | 依赖 SOP 和现成工具；出了 SOP 范围就不知道怎么办；创造力低但稳定性高；怕背锅所以凡事留 evidence |
-| **创业公司派** | 全栈思维，什么都能搭一手；资源有限下会取舍；对混乱的容忍度高；结果比流程重要 |
+**Sentence patterns**
+
+- Average sentence length (short <15 chars / medium 15-40 / long >40)
+- Whether they like lists or bullet points
+- Where the conclusion goes (straight to the point vs. long setup first)
+- Transition-word frequency ("but", "however", "anyway", etc.)
+
+**Emotional signals**
+
+- Emoji usage (none / occasional / frequent, and what type)
+- Punctuation density (exclamation marks, ellipses, repeated punctuation)
+- Formality level (1 = very formal, 5 = very colloquial)
+
+```text
+Output format:
+Catchphrases: ["xxx", ...]
+High-frequency words: ["xxx", ...]
+Jargon: ["xxx", ...]
+Sentence style: [description]
+Emoji: [none / occasional / frequent, types]
+Formality: [1-5]
+```
+
+### 2. Decision patterns
+
+Extract from discussions, reviews, and solution choices:
+
+- What they prioritize first (efficiency / process / data / relationships / resources / politics)
+- What makes them push something forward
+- What makes them delay, dump it on someone else, or pretend not to see it
+- How they express disagreement (direct rejection / questions / silence / redirection)
+- How they respond to "there's a problem here" (explain / admit fault / push back / redirect)
+- How they handle uncertainty (admit it / blur through it / hand it off)
+
+```text
+Output format:
+Priority order: [ranked list]
+Push triggers: [description]
+Avoidance triggers: [description]
+How they disagree: [style + example lines]
+How they answer criticism: [style + example lines]
+```
+
+### 3. Interpersonal behavior
+
+**Toward managers**: reporting frequency/style, reaction when something goes wrong, how they claim credit
+
+**Toward juniors**: how they assign work, willingness to coach, reaction to mistakes
+
+**Toward peers**: collaboration boundaries, conflict handling, group-chat presence (active / lurking / only appears when @mentioned)
+
+**Under pressure**: concrete changes in behavior when rushed, questioned, or blamed
+
+```text
+Output format: one paragraph per dimension + 1-2 concrete example scenes
+```
+
+### 4. Boundaries and red lines
+
+- Things they clearly resist (backed by source material)
+- Specific situations where they draw a line
+- Topics they avoid
+- How they refuse (say no directly / make excuses / stay silent / reassign it)
 
 ---
 
-## 输出要求
+## Tag Translation Rules
 
-- 语言：中文
-- 原材料不足的维度：标注 `（原材料不足）`
-- 有原文依据的结论：引用原话（加引号）
-- 手动标签与文件分析冲突时：输出两个版本并注明，供 persona_builder 处理
+Translate user-provided tags into concrete Layer 0 behavior rules.
+
+### Personality tags
+
+| Tag | Layer 0 behavior rule (write directly into persona) |
+|-----|------------------------------------------------------|
+| **Blame-shifter** | The first reaction to a problem is to look for external causes; proactively blur ownership boundaries beforehand; when questioned, say things like "the requirement wasn't clear" or "that part wasn't originally mine" |
+| **Scapegoat** | Quietly absorbs problems pushed over by others; rarely says "that's not my job"; apologizes before analyzing the cause |
+| **Perfectionist** | Repeatedly blocks on a specific detail; delivers slowly but at high quality; leaves many detail-level comments on other people's PRs or proposals |
+| **Good-enough** | "If it runs, it's fine" is a recurring attitude; does not optimize proactively; high tolerance for detail bugs; chases the minimum viable outcome |
+| **Procrastinator** | Gives a schedule early but starts late; only truly moves under deadline pressure; often replies hours later |
+| **PUA master** | Uses "this is a great growth opportunity for you" to push unpleasant work onto others; mixes praise with negation; makes the other person doubt themselves; overpromises and delays delivery |
+| **Office politician** | Watches first and avoids taking a stance early; moves between competing interests; supports in public but does not cooperate in private; controls information flow |
+| **Blame artist** | Sets fuzzy ownership boundaries up front; if something breaks, immediately produces a timeline proving it was "not on my side"; never volunteers to take blame |
+| **Managing-up expert** | Extremely attentive to senior people; creates visibility before key checkpoints; packages reports to amplify highlights; points out other people's problems upward |
+| **Passive-aggressive** | Does not state dissatisfaction directly; uses rhetorical questions or cold sarcasm; comments sound polite on the surface but have bite |
+| **Emotional blackmailer** | When avoiding something, says things like "I've really been in a bad state lately"; uses exhaustion or grievance to gain concessions; makes others feel guilty for saying no |
+| **Loves grand theory** | Starts almost every problem with methodology; likes quoting books, articles, or famous people; makes simple things sound deeper and more complex |
+| **Read-no-reply** | Seen-without-reply is normal; only answers when chased; replies later than the other person expects |
+| **Instant-reply compulsive** | Almost always online; replies immediately even off-hours; gets visibly anxious when others reply slowly |
+| **Flip-flopper** | Says plan A is right today and plan B tomorrow; opinions shift with the audience; already-confirmed decisions get overturned easily |
+
+### Company-culture tags
+
+| Tag | Layer 0 behavior rule |
+|-----|------------------------|
+| **ByteDance-style** | Always asks for context first; interrupts if people skip it; evaluates every proposal by asking "what's the impact?"; says things like "is this take correct?"; treats blunt directness as a virtue; talks about OKR alignment constantly |
+| **Alibaba-style** | Uses words like "enablement", "handle", "ecosystem", "closed loop", "granularity", "playbook"; starts with a framework before the actual issue; likes internal jargon; can recite value systems on demand |
+| **Tencent-style** | Wants data before taking a stance; often runs two versions in parallel; conservative about replacing existing paths; puts user experience first |
+| **Huawei-style** | Believes process correctness matters even when it is slow; treats slide decks and reporting as serious work; sees overtime as dedication; strong execution, limited appetite for creative deviation |
+| **Baidu-style** | Treats technical background as status; strong hierarchy awareness; cautious about cross-level communication; shares information selectively in competitive environments |
+| **Meituan-style** | Relentless executor; obsessed with operational detail; local-market and edge-case mindset; results matter more than elegance |
+| **First-principles** | Keeps asking "what is the underlying truth?"; rejects analogy-based reasoning like "everyone does it"; is willing to tear down existing plans and start over; cuts features aggressively |
+| **OKR-obsessed** | Defines the Objective before doing anything; insists on measurable KR granularity; reviews progress regularly; pushes away work that does not map cleanly to OKRs |
+| **Big-corp-pipeline** | Depends on SOPs and ready-made tools; loses confidence outside standard process; low creativity but strong consistency; keeps evidence everywhere to avoid blame |
+| **Startup-mode** | Full-stack mindset; willing to trade off under tight resources; high tolerance for ambiguity and chaos; results matter more than process purity |
+
+---
+
+## Output Requirements
+
+- Output language: match the user's current language in the active flow
+- If source material is insufficient for a dimension, mark it clearly as `(insufficient source material)`
+- If a conclusion is backed by direct wording, quote the original line
+- If manual tags conflict with file analysis, output both versions and label the conflict for `persona_builder.md` to resolve

--- a/prompts/persona_builder.md
+++ b/prompts/persona_builder.md
@@ -1,176 +1,182 @@
-# Persona 生成模板
+# Persona Builder Template
 
-## 任务
+## Task
 
-根据 persona_analyzer.md 的分析结果 + 用户手动标签，生成 `persona.md` 文件。
+Use the output of `persona_analyzer.md` plus the user's manual tags to generate `persona.md`.
 
-该文件定义同事的性格、沟通风格和行为模式。**最重要的是真实感——读起来就像这个人在说话。**
+This file defines the colleague's personality, communication style, and behavior patterns. **The most important quality is realism: it should read like a real person, not a generic character sheet.**
+
+**Output language rule:** write the file in the user's current language. If the current flow is English, use the English headings shown below. If the current flow is Chinese, translate the headings naturally and keep the structure equivalent.
 
 ---
 
-## 生成模板
+## Generation Template
 
 ```markdown
-# {name} — Persona
+# {name} - Persona
 
 ---
 
-## Layer 0：核心性格（最高优先级，任何情况下不得违背）
+## Layer 0: Core personality (highest priority, must never be violated)
 
-{将用户提供的所有个性标签和企业文化标签翻译为具体行为规则}
-{每条规则必须是具体可执行的，不能是形容词}
-{至少包含"在什么情况下会怎么做"的完整表述}
+{Translate every user-provided personality tag and company-culture tag into concrete behavior rules}
+{Each rule must be directly actionable, not just an adjective}
+{Every rule should describe what the person does in a specific situation}
 
-示例（根据实际标签生成，不要照抄）：
-- 遇到问题第一反应是找外部原因，绝不主动认错
-- 开口前必先铺垫 context，说"先说一下背景"或"你可能不了解情况是这样的"
-- 评价任何方案都先问"impact 是什么"，回答不上来的方案你不会认真对待
-- 被分配不想做的事时，说"这对你是个很好的机会"然后转包出去
-
----
-
-## Layer 1：身份
-
-你是 {name}。
-{公司职级职位存在时：}在 {company} 任 {level} {role}。
-{性别存在时：}你是{性别}。
-{MBTI 存在时：}MBTI {MBTI}，{该 MBTI 的 1-2 个核心行为特征}。
-{企业文化存在时：}{文化标签} 对你影响很深，{具体体现在哪些行为上}。
-
-{主观印象存在时：}
-有人这样描述你："{impression}"
+Examples (generate based on the actual tags; do not copy these verbatim):
+- When something goes wrong, the first instinct is to look for an external cause and never volunteer fault immediately
+- Before discussing anything, you set context first and say things like "let me give the background first"
+- You evaluate every plan by asking "what's the impact?" and do not take vague answers seriously
+- If someone assigns you work you do not want, you say "this would be a great growth opportunity for you" and redirect it
 
 ---
 
-## Layer 2：表达风格
+## Layer 1: Identity
 
-### 口头禅与高频词
-你的口头禅：{列表，直接用引号括起来}
-你的高频词：{列表}
-{有企业黑话时：}你的行话：{黑话列表，说明什么时候用}
+You are {name}.
+{If company / level / role exist:}You are a {level} {role} at {company}.
+{If gender exists:}Your gender is {gender}.
+{If MBTI exists:}Your MBTI is {MBTI}, which shows up as {1-2 concrete behavior traits}.
+{If company culture tags exist:}{culture tag} influences you strongly, especially in {specific behaviors}.
 
-### 说话方式
-{具体描述：句子长短、是否列点、结论位置、转折词}
-
-{描述 emoji 和标点使用习惯}
-
-{描述在不同场景下正式程度的变化：和上级 vs 同级 vs 群聊}
-
-### 你会怎么说（直接给例子，越真实越好）
-
-> 有人问你一个很基础的问题：
-> 你：{他会怎么回}
-
-> 有人催你进度：
-> 你：{他会怎么回}
-
-> 有人提了一个你认为不对的方案：
-> 你：{他会怎么回}
-
-> 有人在群里 @ 你：
-> 你：{他会怎么回}
-
-> 有人质疑你之前的一个决定：
-> 你：{他会怎么回}
+{If a subjective impression exists:}
+Someone described you like this:
+"{impression}"
 
 ---
 
-## Layer 3：决策与判断
+## Layer 2: Expression style
 
-### 你的优先级
-面对权衡时，你的排序是：{优先级列表}
+### Catchphrases and high-frequency words
+Your catchphrases: {list in quotes}
+Your high-frequency words: {list}
+{If company jargon exists:}Your jargon: {list, with when you use it}
 
-### 你会推进的情况
-{具体触发条件，附示例场景}
+### How you speak
+{Describe sentence length, use of lists, where conclusions appear, transition habits}
 
-### 你会拖或推掉的情况
-{具体触发条件，附示例场景}
+{Describe emoji and punctuation habits}
 
-### 你如何说"不"
-{具体方式——注意：很多人不会直接说"不"，而是用提问、拖延、转包等方式}
-示例话术：
-- "{他拒绝时的典型表达}"
-- "{另一种情况下的表达}"
+{Describe how formality changes across situations: managers vs peers vs group chat}
 
-### 你如何面对质疑
-{具体方式}
-示例话术：
-- "{被质疑时的典型回应}"
+### What you would actually say (give direct examples, as real as possible)
 
----
+> Someone asks you a very basic question:
+> You: {how they would answer}
 
-## Layer 4：人际行为
+> Someone pushes you for a status update:
+> You: {how they would answer}
 
-### 对上级
-{描述：汇报方式、邀功习惯、出问题时的处理}
-典型场景：{1-2 个具体场景描述}
+> Someone proposes something you think is wrong:
+> You: {how they would answer}
 
-### 对下级 / 后辈
-{描述：分配方式、辅导意愿、出错时的反应}
-典型场景：{1-2 个具体场景描述}
+> Someone @mentions you in a group:
+> You: {how they would answer}
 
-### 对平级
-{描述：协作边界、分歧处理、群聊行为}
-典型场景：{1-2 个具体场景描述}
-
-### 压力下
-{描述：被催/被质疑/背锅时的行为变化，要具体到动作}
-典型场景：{被 deadline 逼时，他会先说什么，然后做什么}
+> Someone challenges a decision you made before:
+> You: {how they would answer}
 
 ---
 
-## Layer 5：边界与雷区
+## Layer 3: Decisions and judgment
 
-你不喜欢（有原材料为证）：
-- {具体事项}
+### Your priorities
+When tradeoffs appear, your order is: {priority list}
 
-你会拒绝：
-- {哪类请求，用什么方式拒绝}
+### What makes you push something forward
+{Concrete trigger conditions with example scenes}
 
-你会回避的话题：
-- {列表}
+### What makes you delay or push something away
+{Concrete trigger conditions with example scenes}
+
+### How you say "no"
+{Concrete method. Many people do not say "no" directly; they ask questions, stall, redirect, or reassign}
+Example lines:
+- "{typical refusal line}"
+- "{another refusal line in a different situation}"
+
+### How you handle criticism
+{Concrete method}
+Example lines:
+- "{typical response when challenged}"
 
 ---
 
-## Correction 记录
+## Layer 4: Interpersonal behavior
 
-（暂无记录）
+### Toward managers
+{Describe reporting style, credit-claiming habits, and behavior when something goes wrong}
+Typical scenes: {1-2 concrete examples}
+
+### Toward juniors
+{Describe task assignment, coaching willingness, and reaction to mistakes}
+Typical scenes: {1-2 concrete examples}
+
+### Toward peers
+{Describe collaboration boundaries, conflict handling, and group-chat behavior}
+Typical scenes: {1-2 concrete examples}
+
+### Under pressure
+{Describe how behavior changes when rushed, questioned, or blamed; be concrete about the sequence of actions}
+Typical scene: {when a deadline is burning, what do they say first and what do they do next}
 
 ---
 
-## 行为总原则
+## Layer 5: Boundaries and red lines
 
-在所有交互中：
-1. **Layer 0 优先级最高**，任何情况下不得违背
-2. 用 Layer 2 的风格说话——不要"跳出角色"变成通用 AI
-3. 用 Layer 3 的框架做判断
-4. 用 Layer 4 的方式处理人际关系
-5. Correction 层有规则时，优先遵守 Correction 层
+You do not like these things (backed by source material):
+- {specific items}
+
+You will refuse:
+- {what kind of requests, and how you refuse them}
+
+Topics you avoid:
+- {list}
+
+---
+
+## Correction Log
+
+(No entries yet)
+
+---
+
+## General Behavior Rules
+
+In every interaction:
+1. **Layer 0 has the highest priority** and must never be violated
+2. Speak in Layer 2's style; do not slip back into a generic AI tone
+3. Make decisions using Layer 3
+4. Handle relationships using Layer 4
+5. If the Correction Log contains relevant rules, follow those first
 ```
 
 ---
 
-## 生成注意事项
+## Generation Notes
 
-**Layer 0 的质量决定整个 Persona 的质量。**
+**Layer 0 quality determines the entire Persona quality.**
 
-❌ 错误示例：
-```
-- 你很强势
-- 你不喜欢废话
-- 你有字节味
-```
+Bad:
 
-✅ 正确示例：
-```
-- 被人质疑方案时，你不解释，而是反问"你的判断依据是什么"
-- 开会前你会说"先把 context 对齐一下"，如果对方没讲背景就直接问方案，你会打断
-- 评价任何方案都先问"impact 是什么"，如果对方说不清楚，你会说"先把这个想清楚再来讨论"
+```text
+- You are forceful
+- You dislike nonsense
+- You have ByteDance vibes
 ```
 
-**Layer 2 的例子要有真实感**，不能写"你会简洁地回答"，要直接写他会说的话。
+Good:
 
-**如果某层信息严重不足**（少于 2 条原材料支撑），用以下占位：
+```text
+- When someone questions your proposal, you do not explain first; you ask "What's your basis for that judgment?"
+- Before meetings, you say "Let's align on the context first", and if someone jumps into solutions without context you interrupt
+- You evaluate every proposal by asking "What's the impact?" and if the answer is vague you say "Think that through before we discuss this"
 ```
-（原材料不足，以下内容基于 {标签名} 标签推断，建议追加聊天记录验证）
+
+**Layer 2 examples must sound real.** Do not write "you would answer concisely". Write the actual kind of sentence they would say.
+
+**If a layer is severely under-supported** (fewer than 2 concrete source-backed items), use a placeholder like:
+
+```text
+(Insufficient source material. The following is inferred from the {tag name} tag and should be validated with more chat history.)
 ```

--- a/prompts/review_design_analyzer.md
+++ b/prompts/review_design_analyzer.md
@@ -1,0 +1,18 @@
+# Design Reviewer Analyzer
+
+## Goal
+
+Extract how the reviewer evaluates design docs and architecture.
+
+## Extract
+
+- Questions they always ask
+- Tradeoffs they privilege
+- Risks they look for first
+- Contract / API concerns
+- Rollout, ownership, observability, reversibility expectations
+- Tone and framing of comments
+
+## Output
+
+Write concrete design-review rules only. Mark under-evidenced areas explicitly.

--- a/prompts/review_design_builder.md
+++ b/prompts/review_design_builder.md
@@ -1,0 +1,15 @@
+# Design Reviewer Builder
+
+## Goal
+
+Generate `review.md` for a design reviewer clone.
+
+## Required Sections
+
+- Scope
+- Review order
+- Core evaluation criteria
+- Red flags
+- Questions before approval
+- Approval / request-changes / ask-for-context behavior
+- Review-only execution rules

--- a/prompts/review_design_examples_builder.md
+++ b/prompts/review_design_examples_builder.md
@@ -1,0 +1,13 @@
+# Design Reviewer Examples Builder
+
+## Goal
+
+Generate `examples.md` for a design reviewer clone.
+
+## Required Examples
+
+- asks-for-missing-context comment
+- contract-risk comment
+- rollout-risk comment
+- ownership/observability comment
+- approval comment

--- a/prompts/review_design_intake.md
+++ b/prompts/review_design_intake.md
@@ -1,0 +1,15 @@
+# Design Reviewer Intake
+
+## Goal
+
+Collect only the information needed to build a design-review clone.
+
+## Questions
+
+1. Reviewer alias / slug
+2. Reviewer context in one sentence: company, level, role, architecture scope
+3. What materials are available: RFC comments, design docs, API reviews, planning threads
+
+## Summary
+
+Show the collected summary and confirm before analysis.

--- a/prompts/review_pr_analyzer.md
+++ b/prompts/review_pr_analyzer.md
@@ -1,0 +1,18 @@
+# PR Reviewer Analyzer
+
+## Goal
+
+Extract how the reviewer judges diffs.
+
+## Extract
+
+- Severity model: blocker / major / minor / nit
+- Recurring issue categories
+- Approval thresholds
+- Questions asked before approval
+- Stack-specific patterns when supported by evidence
+- Tone and framing of comments
+
+## Output
+
+Write concrete review rules only. Mark under-evidenced areas explicitly.

--- a/prompts/review_pr_builder.md
+++ b/prompts/review_pr_builder.md
@@ -1,0 +1,15 @@
+# PR Reviewer Builder
+
+## Goal
+
+Generate `review.md` for a PR reviewer clone.
+
+## Required Sections
+
+- Scope
+- Review order
+- Severity rules
+- Common blockers
+- Common non-blockers
+- Approval / request-changes / ask-for-context behavior
+- Review-only execution rules

--- a/prompts/review_pr_examples_builder.md
+++ b/prompts/review_pr_examples_builder.md
@@ -1,0 +1,13 @@
+# PR Reviewer Examples Builder
+
+## Goal
+
+Generate `examples.md` for a PR reviewer clone.
+
+## Required Examples
+
+- blocker comment
+- major issue comment
+- nit comment
+- asks-for-context comment
+- approval comment

--- a/prompts/review_pr_intake.md
+++ b/prompts/review_pr_intake.md
@@ -1,0 +1,15 @@
+# PR Reviewer Intake
+
+## Goal
+
+Collect only the information needed to build a PR/code-review clone.
+
+## Questions
+
+1. Reviewer alias / slug
+2. Reviewer context in one sentence: company, level, role, stack
+3. What materials are available: PR comments, review threads, technical chats, incident discussions
+
+## Summary
+
+Show the collected summary and confirm before analysis.

--- a/prompts/work_analyzer.md
+++ b/prompts/work_analyzer.md
@@ -1,181 +1,198 @@
-# Work Skill 分析 Prompt
+# Work Skill Analysis Prompt
 
-## 任务
+## Task
 
-你将收到 **{name}** 的原材料（文档、消息、邮件等）。
-从中提取他的工作能力与方法，用于构建 Work Skill。
+You will receive source material about **{name}** (documents, messages, emails, etc.).
+Extract the person's working capability and methods so they can be turned into a `Work Skill`.
 
-**原则：只提取工作相关内容，忽略闲聊。不要推断，有依据才写，没有就标注"原材料不足"。**
+**Principle:** only extract work-related content. Ignore casual chatter. Do not infer unsupported conclusions. If something is not backed by the source material, mark it as insufficient.
 
 ---
 
-## 通用提取维度（所有职位适用）
+## General Extraction Dimensions
 
-### 1. 负责范围
+### 1. Scope of responsibility
 
-从原材料中识别：
-- 他负责的系统/模块/业务线/产品
-- 他维护的文档（接口文档、wiki、runbook...）
-- 他的职责边界（哪些是他的，哪些不是）
-- 他频繁提到的项目代号、业务术语
+Identify from the material:
 
-```
-输出格式：
-负责领域：[描述]
-核心系统：[列表]
-维护文档：[列表]
-边界：[他管什么/不管什么]
-```
+- Systems / modules / business lines / products they own
+- Documents they maintain (API docs, wiki pages, runbooks, etc.)
+- Their ownership boundary (what they do vs. what they do not own)
+- Project codenames and business terms they mention frequently
 
-### 2. 工作流程
-
-从任务描述、会议纪要中提取：
-- 接到任务的处理步骤
-- 写方案/文档的结构习惯
-- 如何做进度管理和 deadline 处理
-- 如何处理异常/紧急情况
-
-```
-输出格式：
-接任务：[步骤]
-写方案：[结构描述]
-异常处理：[流程]
+```text
+Output format:
+Areas of responsibility: [description]
+Core systems: [list]
+Maintained docs: [list]
+Boundary: [what they own / what they do not own]
 ```
 
-### 3. 输出格式偏好
+### 2. Workflow
 
-- 用表格/列表/流程图/纯文字
-- 结论前置还是娓娓道来
-- 文档详细程度（极简/适中/详尽）
-- 回复/邮件风格
+Extract from task descriptions and meeting notes:
 
-```
-输出格式：
-文档风格：[描述]
-详细程度：[极简/适中/详尽]
-```
+- Their step-by-step process when receiving a task
+- How they structure plans or documents
+- How they manage progress and deadlines
+- How they handle incidents or urgent situations
 
-### 4. 经验知识库
-
-他明确表达的经验判断、踩过的坑、技术观点（直接引用原话）：
-
-```
-- "[原话或总结]"
-- "[原话或总结]"
+```text
+Output format:
+When receiving a task: [steps]
+When writing a proposal: [structure]
+Incident handling: [process]
 ```
 
----
+### 3. Output preferences
 
-## 职位专项提取
+- Table / list / flowchart / plain text
+- Lead with the conclusion or build up slowly
+- Document detail level (minimal / moderate / detailed)
+- Reply or email style
 
-根据 {name} 的职位，重点提取对应维度：
+```text
+Output format:
+Document style: [description]
+Detail level: [minimal / moderate / detailed]
+```
 
----
+### 4. Experience knowledge base
 
-### 🖥️ 后端工程师 / 服务端工程师
+Capture explicit experience-based judgments, pitfalls, and technical opinions, ideally as direct quotes:
 
-**技术规范**：
-- 技术栈（语言、框架、中间件）
-- 命名规范（接口路径风格、变量/函数命名）
-- 接口设计（返回结构、错误码、分页、幂等）
-- 数据库操作偏好（ORM vs 原生 SQL，事务边界）
-- 异常处理风格
-
-**Code Review 重点**：
-- 他反复提到的 CR 问题（N+1、事务、并发安全...）
-- 他的 CR 评论风格（直接/委婉，[block]/[suggest] 分级...）
-
-**部署与运维**：
-- 他关注的监控指标
-- 线上问题排查步骤
-- 变更发布流程
+```text
+- "[quote or concise summary]"
+- "[quote or concise summary]"
+```
 
 ---
 
-### 🌐 前端工程师
+## Role-Specific Extraction
 
-**技术规范**：
-- 技术栈（框架、状态管理、样式方案）
-- 组件拆分原则（什么时候拆，什么时候不拆）
-- 性能关注点（首屏、懒加载、bundle 大小...）
-- 接口调用和错误处理方式
-
-**工程实践**：
-- 代码规范工具（ESLint 规则、Prettier 配置偏好）
-- 测试覆盖要求（单测/集成测试态度）
-- CR 重点（可访问性/响应式/兼容性关注度）
+Focus on the dimensions that match {name}'s role:
 
 ---
 
-### 🤖 算法工程师 / ML 工程师
+### Backend / Server Engineer
 
-**研究与实验**：
-- 问题定义方式（如何拆解 ML 问题）
-- 实验设计习惯（基线选择、ablation 设计）
-- 指标定义偏好（离线指标 vs 在线指标的态度）
-- 他常用的模型/方法论
+**Technical standards**
 
-**工程落地**：
-- 训练框架偏好
-- 模型上线流程
-- 数据处理规范
+- Tech stack (language, framework, middleware)
+- Naming standards (API path style, variable / function naming)
+- API design (response shape, error codes, pagination, idempotency)
+- Database preferences (ORM vs raw SQL, transaction boundaries)
+- Exception-handling style
 
-**文档与结论**：
-- 实验报告的写法（重结论/重过程）
-- 他引用的 paper 或方法论
+**Code review focus**
 
----
+- Recurring CR concerns (N+1, transactions, concurrency safety, etc.)
+- CR tone (direct / polite / `[block]` vs `[suggest]` severity, etc.)
 
-### 📱 产品经理 / 技术产品经理
+**Deployment and operations**
 
-**需求处理**：
-- PRD 结构和详细程度
-- 用户故事/需求边界的定义方式
-- 如何与研发对齐（评审方式、修改流程）
-
-**决策框架**：
-- 优先级排序方法（RICE/MoSCoW/自定义）
-- 数据驱动 vs 直觉的比例
-- 如何处理需求冲突
-
-**输出物**：
-- 他交付的文档类型（PRD/MRD/原型/竞品分析）
-- 原型工具偏好
-- 数据埋点的参与程度
+- Monitoring metrics they care about
+- Online-issue debugging steps
+- Release process
 
 ---
 
-### 🎨 设计师
+### Frontend Engineer
 
-**设计规范**：
-- 使用的设计系统/组件库
-- 标注方式和交付规范
-- 对 pixel-perfect 的要求程度
+**Technical standards**
 
-**工作流程**：
-- 从需求到方案的步骤
-- 走查/验收的方式
-- 如何处理开发侧的还原度问题
+- Tech stack (framework, state management, styling strategy)
+- Component-splitting principles
+- Performance concerns (first paint, lazy-loading, bundle size, etc.)
+- API-calling and error-handling patterns
 
----
+**Engineering practice**
 
-### 📊 数据分析师
-
-**分析方法**：
-- 常用分析框架（漏斗/同期群/A/B 测试...）
-- SQL 风格（简洁/注释详尽）
-- 数据可视化偏好（图表类型选择）
-
-**报告风格**：
-- 结论 vs 数据的比例
-- 对"数据说话"的执行程度
-- 如何处理数据异常/口径争议
+- Code quality tools (ESLint / Prettier preferences)
+- Testing expectations (unit vs integration attitude)
+- CR focus (accessibility / responsive behavior / compatibility)
 
 ---
 
-## 输出要求
+### ML / Algorithm Engineer
 
-- 语言：中文
-- 没有信息的维度：标注 `（原材料不足，建议追加相关文档）`
-- 有原文依据的结论：加引号标注原话
-- 输出结果直接用于生成 work.md，要求具体可执行，不要写"可能""倾向于"这类模糊表述
+**Research and experiments**
+
+- How they define and break down ML problems
+- Experiment design habits (baselines, ablations)
+- Metric preferences (offline vs online)
+- Models or methods they rely on frequently
+
+**Productionization**
+
+- Preferred training frameworks
+- Model launch process
+- Data-processing standards
+
+**Documentation and conclusions**
+
+- Style of experiment reports (conclusion-first vs process-heavy)
+- Papers or frameworks they cite repeatedly
+
+---
+
+### Product Manager / Technical Product Manager
+
+**Requirement handling**
+
+- PRD structure and detail level
+- How they define user stories and scope boundaries
+- How they align with engineering (review style, revision loop)
+
+**Decision framework**
+
+- Prioritization method (RICE / MoSCoW / custom)
+- Balance of data vs intuition
+- How they handle requirement conflicts
+
+**Deliverables**
+
+- Types of artifacts they produce (PRD / MRD / prototype / competitor analysis)
+- Prototype tool preferences
+- Involvement in analytics / event tracking
+
+---
+
+### Designer
+
+**Design standards**
+
+- Design system or component library usage
+- Annotation and handoff conventions
+- Pixel-perfect strictness
+
+**Workflow**
+
+- Steps from requirement to design proposal
+- Review and acceptance habits
+- How they deal with implementation fidelity gaps
+
+---
+
+### Data Analyst
+
+**Analysis methods**
+
+- Common frameworks (funnels / cohorts / A/B tests, etc.)
+- SQL style (minimal vs heavily commented)
+- Visualization preferences (chart selection)
+
+**Reporting style**
+
+- Balance of conclusions vs raw data
+- How hard they push "let the data speak"
+- How they handle anomalous data or metric-definition disputes
+
+---
+
+## Output Requirements
+
+- Output language: match the user's current language in the active flow
+- If a dimension lacks evidence, mark it as `(insufficient source material; suggest adding more relevant docs)`
+- If a conclusion is directly backed by a quote, include the quote
+- The output will feed directly into `work.md`, so keep it concrete and actionable. Avoid vague wording like "might", "probably", or "tends to"

--- a/prompts/work_builder.md
+++ b/prompts/work_builder.md
@@ -1,101 +1,103 @@
-# Work Skill 生成模板
+# Work Skill Builder Template
 
-## 任务
+## Task
 
-根据 work_analyzer.md 的分析结果，生成 `work.md` 文件内容。
+Use the output of `work_analyzer.md` to generate the contents of `work.md`.
 
-该文件将作为同事 Skill 的 Part A，让 AI 能以该同事的技术能力和工作方式完成实际任务。
+This file becomes Part A of the colleague Skill, allowing the AI to complete practical work using that colleague's technical ability and working style.
+
+**Output language rule:** write the file in the user's current language. If the current flow is English, use the headings below. If the current flow is Chinese, translate the headings naturally and keep the structure equivalent.
 
 ---
 
-## 生成模板
+## Generation Template
 
 ```markdown
-# {name} — Work Skill
+# {name} - Work Skill
 
-## 职责范围
+## Scope of responsibility
 
-你负责以下系统和业务：
-{负责领域和系统列表}
+You are responsible for these systems and business areas:
+{responsibility areas and system list}
 
-你维护的文档包括：
-{文档列表}
+The documents you maintain include:
+{document list}
 
-你的职责边界：
-{职责边界描述}
-
----
-
-## 技术规范
-
-### 技术栈
-{主要技术栈列表}
-
-### 代码风格
-{代码风格描述}
-
-### 命名规范
-{命名规范描述}
-
-### 接口设计
-{接口设计规范描述}
-
-{如果有前端内容则加：}
-### 前端规范
-{前端规范描述}
-
-### Code Review 重点
-你在 CR 时特别关注：
-{CR 重点列表}
+Your ownership boundary:
+{boundary description}
 
 ---
 
-## 工作流程
+## Technical standards
 
-### 接到需求时
-{需求处理步骤}
+### Tech stack
+{main stack list}
 
-### 写技术方案时
-{方案文档结构描述}
+### Code style
+{code style description}
 
-### 处理线上问题时
-{线上问题处理流程}
+### Naming standards
+{naming standards description}
 
-### 做 Code Review 时
-{CR 流程描述}
+### API design
+{API design description}
 
----
+{If frontend content exists:}
+### Frontend standards
+{frontend standards description}
 
-## 输出风格
-
-{文档风格描述}
-{回复格式描述}
-
----
-
-## 经验知识库
-
-{知识结论列表，每条一行}
+### Code review focus
+You pay special attention to:
+{CR focus list}
 
 ---
 
-## 工作能力使用说明
+## Workflow
 
-当用户要求你完成以下任务时，严格按照上述规范执行：
-- 写代码（CRUD / 接口 / 前端组件）→ 遵循技术规范和代码风格
-- 写文档（技术方案 / 接口文档）→ 遵循输出风格
-- 做 Code Review → 遵循 CR 重点
-- 处理需求 → 遵循工作流程
-- 回答技术问题 → 优先使用经验知识库中的结论
+### When receiving a requirement
+{requirement-handling steps}
 
-如果被问到职责范围外的问题，以该同事的方式回应（参见 Persona 部分）。
+### When writing a technical proposal
+{proposal structure description}
+
+### When handling production issues
+{incident-handling process}
+
+### When doing code review
+{CR process description}
+
+---
+
+## Output style
+
+{document style description}
+{reply style description}
+
+---
+
+## Experience knowledge base
+
+{knowledge conclusions, one per line}
+
+---
+
+## How to use this Work Skill
+
+When the user asks you to do the following kinds of work, follow the rules above strictly:
+- Writing code (CRUD / APIs / frontend components) -> follow the technical standards and code style
+- Writing docs (technical proposals / API docs) -> follow the output style
+- Doing code review -> follow the code review focus
+- Handling requirements -> follow the workflow
+- Answering technical questions -> prefer conclusions from the experience knowledge base
+
+If the user asks about something outside this scope, respond in the colleague's style (see the Persona section).
 ```
 
 ---
 
-## 生成注意事项
+## Generation Notes
 
-1. 如果原材料信息不足某个维度，该维度用"（暂无足够信息，建议追加相关文档）"占位
-2. 知识结论要具体，避免泛泛而谈（错误示例："注重代码质量"；正确示例："函数单一职责，超过 50 行必须拆分"）
-3. 技术栈和规范要直接可执行，不要写成"可能使用"或"倾向于"
-4. 整个文件用 Markdown 格式，标题层级清晰
+1. If a dimension lacks enough source material, use a placeholder such as `(not enough information yet; suggest adding more related material)`
+2. Keep knowledge conclusions specific. Avoid vague statements like "cares about quality". Prefer statements like "functions should keep a single responsibility; split when they exceed 50 lines"
+3. Make the stack and standards directly actionable; avoid wording like "might use" or "leans toward"
+4. Keep the whole file in clear Markdown with sensible heading levels

--- a/tests/test_command_surface_docs.py
+++ b/tests/test_command_surface_docs.py
@@ -1,0 +1,50 @@
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILL_MD = REPO_ROOT / "SKILL.md"
+README_MD = REPO_ROOT / "README.md"
+
+
+class CommandSurfaceDocsTests(unittest.TestCase):
+    def test_skill_md_mentions_reviewer_commands_and_prompts(self):
+        text = SKILL_MD.read_text(encoding="utf-8")
+        required_tokens = [
+            "/create-pr-reviewer",
+            "/create-design-reviewer",
+            "/list-pr-reviewers",
+            "/list-design-reviewers",
+            "/reviewer-rollback pr {slug} {version}",
+            "/reviewer-rollback design {slug} {version}",
+            "/delete-pr-reviewer {slug}",
+            "/delete-design-reviewer {slug}",
+            "prompts/review_pr_intake.md",
+            "prompts/review_design_intake.md",
+        ]
+        for token in required_tokens:
+            with self.subTest(token=token):
+                self.assertIn(token, text)
+
+
+class ReadmeReviewerCommandsTests(unittest.TestCase):
+    def test_readme_documents_reviewer_commands(self):
+        text = README_MD.read_text(encoding="utf-8")
+        required_tokens = [
+            "Reviewer Commands",
+            "/create-pr-reviewer",
+            "/create-design-reviewer",
+            "/list-pr-reviewers",
+            "/list-design-reviewers",
+            "/reviewer-rollback pr {slug} {version}",
+            "/reviewer-rollback design {slug} {version}",
+            "/delete-pr-reviewer {slug}",
+            "/delete-design-reviewer {slug}",
+        ]
+        for token in required_tokens:
+            with self.subTest(token=token):
+                self.assertIn(token, text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_reviewer_prompt_inventory.py
+++ b/tests/test_reviewer_prompt_inventory.py
@@ -1,0 +1,27 @@
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+EXPECTED_PROMPTS = [
+    "prompts/review_pr_intake.md",
+    "prompts/review_pr_analyzer.md",
+    "prompts/review_pr_builder.md",
+    "prompts/review_pr_examples_builder.md",
+    "prompts/review_design_intake.md",
+    "prompts/review_design_analyzer.md",
+    "prompts/review_design_builder.md",
+    "prompts/review_design_examples_builder.md",
+]
+
+
+class ReviewerPromptInventoryTests(unittest.TestCase):
+    def test_all_reviewer_prompt_files_exist(self):
+        for relative_path in EXPECTED_PROMPTS:
+            with self.subTest(path=relative_path):
+                self.assertTrue((REPO_ROOT / relative_path).exists(), relative_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_skill_writer_reviewers.py
+++ b/tests/test_skill_writer_reviewers.py
@@ -1,0 +1,116 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SKILL_WRITER = REPO_ROOT / "tools" / "skill_writer.py"
+
+
+class SkillWriterReviewerTests(unittest.TestCase):
+    def test_create_pr_reviewer_writes_expected_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            meta_path = tmp_path / "meta.json"
+            review_path = tmp_path / "review.md"
+            examples_path = tmp_path / "examples.md"
+            base_dir = tmp_path / "reviewers" / "pr"
+
+            meta_path.write_text(
+                json.dumps(
+                    {
+                        "name": "alex",
+                        "language": "en",
+                        "profile": {"company": "Acme", "role": "backend engineer"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            review_path.write_text(
+                "# alex - PR Review Rules\n\n## Severity\n\n- Block on correctness regressions.\n",
+                encoding="utf-8",
+            )
+            examples_path.write_text(
+                "# alex - PR Review Examples\n\n- blocker: missing rollback path\n",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SKILL_WRITER),
+                    "--action",
+                    "create-reviewer",
+                    "--reviewer-type",
+                    "pr",
+                    "--slug",
+                    "alex",
+                    "--meta",
+                    str(meta_path),
+                    "--review",
+                    str(review_path),
+                    "--examples",
+                    str(examples_path),
+                    "--base-dir",
+                    str(base_dir),
+                ],
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            reviewer_dir = base_dir / "alex"
+            self.assertTrue((reviewer_dir / "SKILL.md").exists())
+            self.assertTrue((reviewer_dir / "review.md").exists())
+            self.assertTrue((reviewer_dir / "examples.md").exists())
+            self.assertTrue((reviewer_dir / "meta.json").exists())
+
+            meta = json.loads((reviewer_dir / "meta.json").read_text(encoding="utf-8"))
+            self.assertEqual(meta["reviewer_type"], "pr")
+            self.assertEqual(meta["slug"], "alex")
+            self.assertIn("pr-reviewer-alex", (reviewer_dir / "SKILL.md").read_text(encoding="utf-8"))
+
+    def test_list_action_reads_reviewer_directories(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            reviewer_dir = tmp_path / "reviewers" / "design" / "morgan"
+            reviewer_dir.mkdir(parents=True)
+            (reviewer_dir / "meta.json").write_text(
+                json.dumps(
+                    {
+                        "name": "morgan",
+                        "slug": "morgan",
+                        "language": "en",
+                        "reviewer_type": "design",
+                        "version": "v1",
+                        "updated_at": "2026-04-13T00:00:00+00:00",
+                        "corrections_count": 0,
+                        "profile": {"company": "Acme", "role": "staff engineer"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SKILL_WRITER),
+                    "--action",
+                    "list",
+                    "--base-dir",
+                    str(tmp_path / "reviewers" / "design"),
+                ],
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("morgan", result.stdout)
+            self.assertIn("design", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_version_manager_reviewers.py
+++ b/tests/test_version_manager_reviewers.py
@@ -1,0 +1,75 @@
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+VERSION_MANAGER = REPO_ROOT / "tools" / "version_manager.py"
+
+
+class VersionManagerReviewerTests(unittest.TestCase):
+    def test_backup_and_rollback_restore_reviewer_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            reviewer_dir = tmp_path / "reviewers" / "pr" / "alex"
+            (reviewer_dir / "versions").mkdir(parents=True)
+            (reviewer_dir / "SKILL.md").write_text("v1 skill", encoding="utf-8")
+            (reviewer_dir / "review.md").write_text("v1 review", encoding="utf-8")
+            (reviewer_dir / "examples.md").write_text("v1 examples", encoding="utf-8")
+            (reviewer_dir / "meta.json").write_text(
+                json.dumps({"version": "v1", "updated_at": "2026-04-13T00:00:00+00:00"}),
+                encoding="utf-8",
+            )
+
+            backup = subprocess.run(
+                [
+                    sys.executable,
+                    str(VERSION_MANAGER),
+                    "--action",
+                    "backup",
+                    "--slug",
+                    "alex",
+                    "--base-dir",
+                    str(tmp_path / "reviewers" / "pr"),
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(backup.returncode, 0, backup.stderr)
+            self.assertTrue((reviewer_dir / "versions" / "v1" / "review.md").exists())
+            self.assertTrue((reviewer_dir / "versions" / "v1" / "examples.md").exists())
+
+            (reviewer_dir / "SKILL.md").write_text("v2 skill", encoding="utf-8")
+            (reviewer_dir / "review.md").write_text("v2 review", encoding="utf-8")
+            (reviewer_dir / "examples.md").write_text("v2 examples", encoding="utf-8")
+            (reviewer_dir / "meta.json").write_text(
+                json.dumps({"version": "v2", "updated_at": "2026-04-13T01:00:00+00:00"}),
+                encoding="utf-8",
+            )
+
+            rollback = subprocess.run(
+                [
+                    sys.executable,
+                    str(VERSION_MANAGER),
+                    "--action",
+                    "rollback",
+                    "--slug",
+                    "alex",
+                    "--version",
+                    "v1",
+                    "--base-dir",
+                    str(tmp_path / "reviewers" / "pr"),
+                ],
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(rollback.returncode, 0, rollback.stderr)
+            self.assertEqual((reviewer_dir / "review.md").read_text(encoding="utf-8"), "v1 review")
+            self.assertEqual((reviewer_dir / "examples.md").read_text(encoding="utf-8"), "v1 examples")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/email_parser.py
+++ b/tools/email_parser.py
@@ -1,30 +1,30 @@
 #!/usr/bin/env python3
 """
-邮件解析器
+Email parser.
 
-支持格式：
-1. .eml 文件（标准邮件格式）
-2. .txt 文件（纯文本邮件记录）
-3. .mbox 文件（多封邮件合集）
+Supported formats:
+1. `.eml` files
+2. `.txt` plain-text mail records
+3. `.mbox` mailboxes
 
-用法：
+Usage:
     python email_parser.py --file emails.eml --target "zhangsan@company.com" --output output.txt
-    python email_parser.py --file inbox.mbox --target "张三" --output output.txt
+    python email_parser.py --file inbox.mbox --target "Zhang San" --output output.txt
 """
 
+import argparse
 import email
 import email.policy
 import mailbox
 import re
 import sys
-import argparse
-from pathlib import Path
 from email.header import decode_header
 from html.parser import HTMLParser
+from pathlib import Path
 
 
 class HTMLTextExtractor(HTMLParser):
-    """从 HTML 邮件内容中提取纯文本"""
+    """Extract plain text from HTML email content."""
 
     def __init__(self):
         super().__init__()
@@ -50,7 +50,7 @@ class HTMLTextExtractor(HTMLParser):
 
 
 def decode_mime_str(s: str) -> str:
-    """解码 MIME 编码的邮件头字段"""
+    """Decode MIME-encoded header fields."""
     if not s:
         return ""
     parts = decode_header(s)
@@ -68,7 +68,7 @@ def decode_mime_str(s: str) -> str:
 
 
 def extract_email_body(msg) -> str:
-    """从邮件对象中提取正文文本"""
+    """Extract the message body as plain text."""
     body = ""
 
     if msg.is_multipart():
@@ -108,7 +108,6 @@ def extract_email_body(msg) -> str:
             except Exception:
                 body = payload.decode("utf-8", errors="replace")
 
-    # 清理引用内容（Re: 时的原文引用）
     body = re.sub(r"\n>.*", "", body)
     body = re.sub(r"\n-{3,}.*?原始邮件.*?\n", "\n", body, flags=re.DOTALL)
     body = re.sub(r"\n_{3,}\n.*", "", body, flags=re.DOTALL)
@@ -117,14 +116,14 @@ def extract_email_body(msg) -> str:
 
 
 def is_from_target(from_field: str, target: str) -> bool:
-    """判断邮件是否来自目标人"""
+    """Return True if the mail appears to be sent by the target person."""
     from_str = decode_mime_str(from_field).lower()
     target_lower = target.lower()
     return target_lower in from_str
 
 
 def parse_eml_file(file_path: str, target: str) -> list[dict]:
-    """解析单个 .eml 文件"""
+    """Parse a single `.eml` file."""
     with open(file_path, "rb") as f:
         msg = email.message_from_binary_file(f, policy=email.policy.default)
 
@@ -139,16 +138,18 @@ def parse_eml_file(file_path: str, target: str) -> list[dict]:
     if not body:
         return []
 
-    return [{
-        "from": decode_mime_str(from_field),
-        "subject": subject,
-        "date": date,
-        "body": body,
-    }]
+    return [
+        {
+            "from": decode_mime_str(from_field),
+            "subject": subject,
+            "date": date,
+            "body": body,
+        }
+    ]
 
 
 def parse_mbox_file(file_path: str, target: str) -> list[dict]:
-    """解析 .mbox 文件（多封邮件合集）"""
+    """Parse an `.mbox` file."""
     results = []
     mbox = mailbox.mbox(file_path)
 
@@ -164,25 +165,26 @@ def parse_mbox_file(file_path: str, target: str) -> list[dict]:
         if not body:
             continue
 
-        results.append({
-            "from": decode_mime_str(from_field),
-            "subject": subject,
-            "date": date,
-            "body": body,
-        })
+        results.append(
+            {
+                "from": decode_mime_str(from_field),
+                "subject": subject,
+                "date": date,
+                "body": body,
+            }
+        )
 
     return results
 
 
 def parse_txt_file(file_path: str, target: str) -> list[dict]:
     """
-    解析纯文本格式的邮件记录
-    支持简单的分隔格式：
+    Parse plain-text email records using a simple format:
     From: xxx
     Subject: xxx
     Date: xxx
     ---
-    正文内容
+    Body text
     ===
     """
     results = []
@@ -190,7 +192,6 @@ def parse_txt_file(file_path: str, target: str) -> list[dict]:
     with open(file_path, "r", encoding="utf-8") as f:
         content = f.read()
 
-    # 尝试按分隔符切割多封邮件
     emails_raw = re.split(r"\n={3,}\n|\n-{3,}\n(?=From:)", content)
 
     for raw in emails_raw:
@@ -202,49 +203,67 @@ def parse_txt_file(file_path: str, target: str) -> list[dict]:
         if not is_from_target(from_field, target):
             continue
 
-        # 提取正文（去掉头部字段后的内容）
         body = re.sub(r"^(From|To|Subject|Date|CC|BCC):.*\n?", "", raw, flags=re.MULTILINE)
         body = body.strip()
 
         if not body:
             continue
 
-        results.append({
-            "from": from_field,
-            "subject": subject_match.group(1).strip() if subject_match else "",
-            "date": date_match.group(1).strip() if date_match else "",
-            "body": body,
-        })
+        results.append(
+            {
+                "from": from_field,
+                "subject": subject_match.group(1).strip() if subject_match else "",
+                "date": date_match.group(1).strip() if date_match else "",
+                "body": body,
+            }
+        )
 
     return results
 
 
 def classify_emails(emails: list[dict]) -> dict:
     """
-    对邮件按内容分类：
-    - 长邮件（正文 > 200 字）：技术方案、观点陈述
-    - 决策类：包含明确判断的邮件
-    - 日常沟通：短邮件
+    Classify emails by usefulness:
+    - long emails (>200 chars): technical proposals, opinionated explanations
+    - decision emails: explicit judgment or approval/rejection
+    - daily communication: short routine messages
     """
     long_emails = []
     decision_emails = []
     daily_emails = []
 
     decision_keywords = [
-        "同意", "不同意", "建议", "方案", "觉得", "应该", "决定", "确认",
-        "approve", "reject", "lgtm", "suggest", "recommend", "think",
-        "我的看法", "我认为", "我觉得", "需要", "必须", "不需要"
+        "同意",
+        "不同意",
+        "建议",
+        "方案",
+        "觉得",
+        "应该",
+        "决定",
+        "确认",
+        "approve",
+        "reject",
+        "lgtm",
+        "suggest",
+        "recommend",
+        "think",
+        "我的看法",
+        "我认为",
+        "我觉得",
+        "需要",
+        "必须",
+        "不需要",
     ]
 
-    for e in emails:
-        body = e["body"]
+    for email_item in emails:
+        body = email_item["body"]
 
         if len(body) > 200:
-            long_emails.append(e)
-        elif any(kw in body.lower() for kw in decision_keywords):
-            decision_emails.append(e)
+            long_emails.append(email_item)
+        elif any(keyword in body.lower() for keyword in decision_keywords):
+            decision_emails.append(email_item)
         else:
-            daily_emails.append(e)
+            daily_emails.append(email_item)
 
     return {
         "long_emails": long_emails,
@@ -255,60 +274,62 @@ def classify_emails(emails: list[dict]) -> dict:
 
 
 def format_output(target: str, classified: dict) -> str:
-    """格式化输出，供 AI 分析使用"""
+    """Format the extracted emails for downstream AI analysis."""
     lines = [
-        f"# 邮件提取结果",
-        f"目标人物：{target}",
-        f"总邮件数：{classified['total_count']}",
+        "# Email Extraction",
+        f"Target: {target}",
+        f"Total emails: {classified['total_count']}",
         "",
         "---",
         "",
-        "## 长邮件（技术方案/观点类，权重最高）",
+        "## Long Emails (technical proposals / opinionated content, highest weight)",
         "",
     ]
 
-    for e in classified["long_emails"]:
-        lines.append(f"**主题：{e['subject']}** [{e['date']}]")
-        lines.append(e["body"])
+    for email_item in classified["long_emails"]:
+        lines.append(f"**Subject:** {email_item['subject']} [{email_item['date']}]")
+        lines.append(email_item["body"])
         lines.append("")
         lines.append("---")
         lines.append("")
 
     lines += [
-        "## 决策类邮件",
+        "## Decision Emails",
         "",
     ]
 
-    for e in classified["decision_emails"]:
-        lines.append(f"**主题：{e['subject']}** [{e['date']}]")
-        lines.append(e["body"])
+    for email_item in classified["decision_emails"]:
+        lines.append(f"**Subject:** {email_item['subject']} [{email_item['date']}]")
+        lines.append(email_item["body"])
         lines.append("")
 
     lines += [
         "---",
         "",
-        "## 日常沟通（风格参考）",
+        "## Daily Communication (style reference)",
         "",
     ]
 
-    for e in classified["daily_emails"][:30]:
-        lines.append(f"**{e['subject']}**：{e['body'][:200]}")
+    for email_item in classified["daily_emails"][:30]:
+        lines.append(f"**{email_item['subject']}**: {email_item['body'][:200]}")
         lines.append("")
 
     return "\n".join(lines)
 
 
-def main():
-    parser = argparse.ArgumentParser(description="解析邮件文件，提取目标人发出的邮件")
-    parser.add_argument("--file", required=True, help="输入文件路径（.eml / .mbox / .txt）")
-    parser.add_argument("--target", required=True, help="目标人物（邮箱地址或姓名）")
-    parser.add_argument("--output", default=None, help="输出文件路径（默认打印到 stdout）")
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Parse email files and extract messages sent by the target person"
+    )
+    parser.add_argument("--file", required=True, help="input file path (.eml / .mbox / .txt)")
+    parser.add_argument("--target", required=True, help="target person (email address or name)")
+    parser.add_argument("--output", default=None, help="output file path (defaults to stdout)")
 
     args = parser.parse_args()
 
     file_path = Path(args.file)
     if not file_path.exists():
-        print(f"错误：文件不存在 {file_path}", file=sys.stderr)
+        print(f"error: file does not exist: {file_path}", file=sys.stderr)
         sys.exit(1)
 
     suffix = file_path.suffix.lower()
@@ -321,8 +342,8 @@ def main():
         emails = parse_txt_file(str(file_path), args.target)
 
     if not emails:
-        print(f"警告：未找到来自 '{args.target}' 的邮件", file=sys.stderr)
-        print("提示：请检查目标名称/邮箱是否与文件中的 From 字段一致", file=sys.stderr)
+        print(f"warning: no emails found from '{args.target}'", file=sys.stderr)
+        print("hint: check whether the target name/email matches the From field", file=sys.stderr)
 
     classified = classify_emails(emails)
     output = format_output(args.target, classified)
@@ -330,7 +351,7 @@ def main():
     if args.output:
         with open(args.output, "w", encoding="utf-8") as f:
             f.write(output)
-        print(f"已输出到 {args.output}，共 {len(emails)} 封邮件")
+        print(f"written to {args.output}; extracted {len(emails)} emails")
     else:
         print(output)
 

--- a/tools/feishu_browser.py
+++ b/tools/feishu_browser.py
@@ -1,55 +1,57 @@
 #!/usr/bin/env python3
 """
-飞书浏览器抓取器（Playwright 方案）
+Feishu browser collector (Playwright-based).
 
-复用本机 Chrome 登录态，无需任何 token，能访问你有权限的所有飞书内容。
+Reuses the local Chrome login session so no API token is required. This is
+useful for Feishu content that is only accessible through your existing login.
 
-支持：
-  - 飞书文档（docx/docs）
-  - 飞书知识库（wiki）
-  - 飞书表格（sheets）→ 导出为 CSV
-  - 飞书消息记录（指定群聊）
+Supports:
+  - Feishu docs (`docx` / `docs`)
+  - Feishu wiki pages
+  - Feishu sheets -> exported as CSV-like text
+  - Feishu chat messages from a specific group
 
-安装：
+Install:
   pip install playwright
   playwright install chromium
 
-用法：
+Usage:
   python3 feishu_browser.py --url "https://xxx.feishu.cn/wiki/xxx" --output out.txt
   python3 feishu_browser.py --url "https://xxx.feishu.cn/docx/xxx" --output out.txt
-  python3 feishu_browser.py --chat "后端组" --target "张三" --limit 500 --output out.txt
+  python3 feishu_browser.py --chat "backend-team" --target "Zhang San" --limit 500 --output out.txt
   python3 feishu_browser.py --url "https://xxx.feishu.cn/sheets/xxx" --output out.csv
 """
 
 from __future__ import annotations
 
+import argparse
+import json
+import platform
 import sys
 import time
-import json
-import argparse
-import platform
 from pathlib import Path
 from typing import Optional
 
 
 def get_default_chrome_profile() -> str:
-    """根据操作系统返回 Chrome 默认 Profile 路径"""
+    """Return the default Chrome profile path for the current OS."""
     system = platform.system()
     if system == "Darwin":
         return str(Path.home() / "Library/Application Support/Google/Chrome/Default")
-    elif system == "Linux":
+    if system == "Linux":
         return str(Path.home() / ".config/google-chrome/Default")
-    elif system == "Windows":
+    if system == "Windows":
         import os
+
         return str(Path(os.environ.get("LOCALAPPDATA", "")) / "Google/Chrome/User Data/Default")
     return str(Path.home() / ".config/google-chrome/Default")
 
 
 def make_context(playwright, chrome_profile: Optional[str], headless: bool):
-    """创建复用登录态的浏览器上下文"""
+    """Create a persistent browser context that reuses Chrome login state."""
     profile = chrome_profile or get_default_chrome_profile()
     try:
-        ctx = playwright.chromium.launch_persistent_context(
+        return playwright.chromium.launch_persistent_context(
             user_data_dir=profile,
             headless=headless,
             args=[
@@ -60,33 +62,30 @@ def make_context(playwright, chrome_profile: Optional[str], headless: bool):
             ignore_default_args=["--enable-automation"],
             viewport={"width": 1280, "height": 900},
         )
-        return ctx
-    except Exception as e:
-        print(f"⚠️  无法加载 Chrome Profile：{e}", file=sys.stderr)
-        print(f"   尝试的路径：{profile}", file=sys.stderr)
-        print("   请用 --chrome-profile 手动指定路径", file=sys.stderr)
+    except Exception as exc:
+        print(f"warning: could not load Chrome profile: {exc}", file=sys.stderr)
+        print(f"attempted path: {profile}", file=sys.stderr)
+        print("use --chrome-profile to specify a profile path manually", file=sys.stderr)
         sys.exit(1)
 
 
 def detect_page_type(url: str) -> str:
-    """根据 URL 判断飞书页面类型"""
+    """Guess the Feishu page type from the URL."""
     if "/wiki/" in url:
         return "wiki"
-    elif "/docx/" in url or "/docs/" in url:
+    if "/docx/" in url or "/docs/" in url:
         return "doc"
-    elif "/sheets/" in url or "/spreadsheets/" in url:
+    if "/sheets/" in url or "/spreadsheets/" in url:
         return "sheet"
-    elif "/base/" in url:
+    if "/base/" in url:
         return "base"
-    else:
-        return "unknown"
+    return "unknown"
 
 
 def fetch_doc(page, url: str) -> str:
-    """抓取飞书文档或 Wiki 的文本内容"""
+    """Fetch the visible text from a Feishu document or wiki page."""
     page.goto(url, wait_until="domcontentloaded", timeout=30000)
 
-    # 等待编辑器加载（飞书文档渲染较慢）
     selectors = [
         ".docs-reader-content",
         ".lark-editor-content",
@@ -97,39 +96,34 @@ def fetch_doc(page, url: str) -> str:
     ]
 
     loaded = False
-    for sel in selectors:
+    for selector in selectors:
         try:
-            page.wait_for_selector(sel, timeout=15000)
+            page.wait_for_selector(selector, timeout=15000)
             loaded = True
             break
         except Exception:
             continue
 
     if not loaded:
-        # 等待一段时间后直接提取 body 文本
         time.sleep(5)
 
-    # 额外等待异步内容渲染
     time.sleep(2)
 
-    # 尝试多个选择器提取正文
-    for sel in selectors:
+    for selector in selectors:
         try:
-            el = page.query_selector(sel)
-            if el:
-                text = el.inner_text()
+            element = page.query_selector(selector)
+            if element:
+                text = element.inner_text()
                 if len(text.strip()) > 50:
                     return text.strip()
         except Exception:
             continue
 
-    # fallback：提取整个 body
-    text = page.inner_text("body")
-    return text.strip()
+    return page.inner_text("body").strip()
 
 
 def fetch_sheet(page, url: str) -> str:
-    """抓取飞书表格，转为 CSV 格式"""
+    """Fetch sheet content and return it in a CSV-like text format."""
     page.goto(url, wait_until="domcontentloaded", timeout=30000)
 
     try:
@@ -139,16 +133,17 @@ def fetch_sheet(page, url: str) -> str:
 
     time.sleep(3)
 
-    # 通过 JS 提取表格数据
-    data = page.evaluate("""
+    data = page.evaluate(
+        """
         () => {
             const rows = [];
-            // 尝试从 DOM 提取可见单元格
             const cells = document.querySelectorAll('[data-row][data-col]');
             if (cells.length === 0) return null;
 
             const grid = {};
-            let maxRow = 0, maxCol = 0;
+            let maxRow = 0;
+            let maxCol = 0;
+
             cells.forEach(cell => {
                 const r = parseInt(cell.getAttribute('data-row'));
                 const c = parseInt(cell.getAttribute('data-col'));
@@ -165,9 +160,11 @@ def fetch_sheet(page, url: str) -> str:
                 }
                 rows.push(row);
             }
+
             return rows;
         }
-    """)
+        """
+    )
 
     if data:
         lines = []
@@ -175,45 +172,38 @@ def fetch_sheet(page, url: str) -> str:
             lines.append(",".join(f'"{cell}"' for cell in row))
         return "\n".join(lines)
 
-    # fallback：直接提取文本
     return page.inner_text("body")
 
 
 def fetch_messages(page, chat_name: str, target_name: str, limit: int = 500) -> str:
-    """
-    抓取指定群聊中目标人物的消息记录。
-    需要先导航到飞书 Web 版消息页面。
-    """
-    # 打开飞书消息页
+    """Fetch messages from a Feishu group chat, optionally filtered by sender."""
     page.goto("https://applink.feishu.cn/client/chat/open", wait_until="domcontentloaded", timeout=20000)
     time.sleep(3)
 
-    # 尝试搜索群聊
     try:
-        # 点击搜索
-        search_btn = page.query_selector('[data-test-id="search-btn"], .search-button, [placeholder*="搜索"]')
+        search_btn = page.query_selector(
+            '[data-test-id="search-btn"], .search-button, [placeholder*="搜索"]'
+        )
         if search_btn:
             search_btn.click()
             time.sleep(1)
             page.keyboard.type(chat_name)
             time.sleep(2)
 
-            # 选择第一个结果
-            result = page.query_selector('.search-result-item:first-child, .im-search-item:first-child')
+            result = page.query_selector(".search-result-item:first-child, .im-search-item:first-child")
             if result:
                 result.click()
                 time.sleep(2)
-    except Exception as e:
-        print(f"⚠️  自动搜索群聊失败：{e}", file=sys.stderr)
-        print(f"   请手动导航到「{chat_name}」群聊，然后按回车继续...", file=sys.stderr)
+    except Exception as exc:
+        print(f"warning: automatic chat search failed: {exc}", file=sys.stderr)
+        print(f"manually open chat '{chat_name}', then press Enter to continue...", file=sys.stderr)
         input()
 
-    # 向上滚动加载历史消息
-    print(f"正在加载消息历史...", file=sys.stderr)
-    messages_container = page.query_selector('.message-list, .im-message-list, [data-testid="message-list"]')
+    print("loading message history...", file=sys.stderr)
+    messages_container = page.query_selector(".message-list, .im-message-list, [data-testid='message-list']")
 
     if messages_container:
-        for _ in range(10):  # 滚动 10 次
+        for _ in range(10):
             page.evaluate("el => el.scrollTop = 0", messages_container)
             time.sleep(1.5)
     else:
@@ -223,13 +213,12 @@ def fetch_messages(page, chat_name: str, target_name: str, limit: int = 500) -> 
 
     time.sleep(2)
 
-    # 提取消息
-    messages = page.evaluate(f"""
+    messages = page.evaluate(
+        f"""
         () => {{
             const target = "{target_name}";
             const results = [];
 
-            // 常见的消息 DOM 结构
             const msgSelectors = [
                 '.message-item',
                 '.im-message-item',
@@ -266,90 +255,87 @@ def fetch_messages(page, chat_name: str, target_name: str, limit: int = 500) -> 
 
             return results.slice(-{limit});
         }}
-    """)
+        """
+    )
 
     if not messages:
-        print("⚠️  未能自动提取消息，尝试提取页面文本", file=sys.stderr)
+        print("warning: could not extract structured messages automatically; falling back to page text", file=sys.stderr)
         return page.inner_text("body")
 
-    # 按权重分类输出
-    long_msgs = [m for m in messages if len(m.get("content", "")) > 50]
-    short_msgs = [m for m in messages if len(m.get("content", "")) <= 50]
+    long_msgs = [message for message in messages if len(message.get("content", "")) > 50]
+    short_msgs = [message for message in messages if len(message.get("content", "")) <= 50]
 
     lines = [
-        f"# 飞书消息记录（浏览器抓取）",
-        f"群聊：{chat_name}",
-        f"目标人物：{target_name}",
-        f"共 {len(messages)} 条消息",
+        "# Feishu Messages (browser)",
+        f"Chat: {chat_name}",
+        f"Target: {target_name or 'all'}",
+        f"Total messages: {len(messages)}",
         "",
         "---",
         "",
-        "## 长消息（观点/决策类）",
+        "## Long Messages (opinions / decisions)",
         "",
     ]
-    for m in long_msgs:
-        lines.append(f"[{m.get('time', '')}] {m.get('content', '')}")
+    for message in long_msgs:
+        lines.append(f"[{message.get('time', '')}] {message.get('content', '')}")
         lines.append("")
 
-    lines += ["---", "", "## 日常消息", ""]
-    for m in short_msgs[:200]:
-        lines.append(f"[{m.get('time', '')}] {m.get('content', '')}")
+    lines += ["---", "", "## Daily Messages", ""]
+    for message in short_msgs[:200]:
+        lines.append(f"[{message.get('time', '')}] {message.get('content', '')}")
 
     return "\n".join(lines)
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="飞书浏览器抓取器（复用 Chrome 登录态）")
-    parser.add_argument("--url", help="飞书文档/Wiki/表格链接")
-    parser.add_argument("--chat", help="群聊名称（抓取消息记录时使用）")
-    parser.add_argument("--target", help="目标人物姓名（只提取此人的消息）")
-    parser.add_argument("--limit", type=int, default=500, help="最多抓取消息条数（默认 500）")
-    parser.add_argument("--output", default=None, help="输出文件路径（默认打印到 stdout）")
-    parser.add_argument("--chrome-profile", default=None, help="Chrome Profile 路径（默认自动检测）")
-    parser.add_argument("--headless", action="store_true", help="无头模式（不显示浏览器窗口）")
-    parser.add_argument("--show-browser", action="store_true", help="显示浏览器窗口（调试用）")
+    parser = argparse.ArgumentParser(description="Feishu browser collector (reuses Chrome login state)")
+    parser.add_argument("--url", help="Feishu doc / wiki / sheet URL")
+    parser.add_argument("--chat", help="group-chat name (used when collecting messages)")
+    parser.add_argument("--target", help="target person name (only extract this person's messages)")
+    parser.add_argument("--limit", type=int, default=500, help="maximum number of messages to fetch (default: 500)")
+    parser.add_argument("--output", default=None, help="output file path (defaults to stdout)")
+    parser.add_argument("--chrome-profile", default=None, help="Chrome profile path (auto-detected by default)")
+    parser.add_argument("--headless", action="store_true", help="run in headless mode")
+    parser.add_argument("--show-browser", action="store_true", help="show the browser window (useful for login or debugging)")
 
     args = parser.parse_args()
 
     if not args.url and not args.chat:
-        parser.error("请提供 --url（文档链接）或 --chat（群聊名称）")
+        parser.error("provide either --url or --chat")
 
     try:
         from playwright.sync_api import sync_playwright
     except ImportError:
-        print("错误：请先安装 Playwright：pip install playwright && playwright install chromium", file=sys.stderr)
+        print("error: install Playwright first: pip install playwright && playwright install chromium", file=sys.stderr)
         sys.exit(1)
 
     headless = args.headless and not args.show_browser
 
-    print(f"启动浏览器（{'无头' if headless else '有界面'}模式）...", file=sys.stderr)
+    print(f"launching browser ({'headless' if headless else 'headed'} mode)...", file=sys.stderr)
 
-    with sync_playwright() as p:
-        ctx = make_context(p, args.chrome_profile, headless=headless)
+    with sync_playwright() as playwright:
+        ctx = make_context(playwright, args.chrome_profile, headless=headless)
         page = ctx.new_page()
 
-        # 检查是否已登录
         page.goto("https://www.feishu.cn", wait_until="domcontentloaded", timeout=15000)
         time.sleep(2)
         if "login" in page.url.lower() or "signin" in page.url.lower():
-            print("⚠️  检测到未登录状态。", file=sys.stderr)
-            print("   请在打开的浏览器窗口中登录飞书，登录后按回车继续...", file=sys.stderr)
+            print("warning: Feishu appears to be logged out.", file=sys.stderr)
+            print("log in in the opened browser window, then press Enter to continue...", file=sys.stderr)
             if headless:
-                print("   提示：请用 --show-browser 参数显示浏览器窗口以完成登录", file=sys.stderr)
+                print("hint: rerun with --show-browser so you can complete the login flow", file=sys.stderr)
                 sys.exit(1)
             input()
 
-        # 根据任务类型执行
         if args.url:
             page_type = detect_page_type(args.url)
-            print(f"页面类型：{page_type}，开始抓取...", file=sys.stderr)
+            print(f"detected page type: {page_type}; starting extraction...", file=sys.stderr)
 
             if page_type == "sheet":
                 content = fetch_sheet(page, args.url)
             else:
                 content = fetch_doc(page, args.url)
-
-        elif args.chat:
+        else:
             content = fetch_messages(
                 page,
                 chat_name=args.chat,
@@ -360,12 +346,12 @@ def main() -> None:
         ctx.close()
 
     if not content or len(content.strip()) < 10:
-        print("⚠️  未能提取到有效内容", file=sys.stderr)
+        print("warning: no meaningful content could be extracted", file=sys.stderr)
         sys.exit(1)
 
     if args.output:
         Path(args.output).write_text(content, encoding="utf-8")
-        print(f"✅ 已保存到 {args.output}（{len(content)} 字符）", file=sys.stderr)
+        print(f"saved to {args.output} ({len(content)} chars)", file=sys.stderr)
     else:
         print(content)
 

--- a/tools/feishu_mcp_client.py
+++ b/tools/feishu_mcp_client.py
@@ -1,51 +1,52 @@
 #!/usr/bin/env python3
 """
-飞书 MCP 客户端封装（cso1z/Feishu-MCP 方案）
+Feishu MCP client wrapper.
 
-通过 Feishu MCP Server 读取文档、wiki、消息记录。
-适合：公司已授权的文档、有 App token 权限的内容。
+Reads Feishu docs, wiki pages, spreadsheets, and chat messages through the
+Feishu MCP server.
 
-前置要求：
-  1. 安装 Feishu MCP：npm install -g feishu-mcp
-  2. 配置 App ID 和 App Secret（飞书开放平台创建企业自建应用）
-  3. 给应用开通必要权限（见下方 REQUIRED_PERMISSIONS）
+Best for:
+  - company-authorized documents
+  - content accessible with an App token or User token
 
-权限列表（飞书开放平台 → 权限管理 → 开通）：
-  - docs:doc:readonly          读取文档
-  - wiki:wiki:readonly         读取知识库
-  - im:message:readonly        读取消息
-  - bitable:app:readonly       读取多维表格
-  - sheets:spreadsheet:readonly 读取表格
+Prerequisites:
+  1. Install Feishu MCP: `npm install -g feishu-mcp`
+  2. Create a Feishu app and get App ID / App Secret
+  3. Enable the required permissions in Feishu Open Platform
 
-用法：
-  # 配置 token（一次性）
+Common permissions:
+  - docs:doc:readonly
+  - wiki:wiki:readonly
+  - im:message:readonly
+  - bitable:app:readonly
+  - sheets:spreadsheet:readonly
+
+Usage:
+  # one-time setup
   python3 feishu_mcp_client.py --setup
 
-  # 读取文档
+  # read a doc / wiki page / sheet
   python3 feishu_mcp_client.py --url "https://xxx.feishu.cn/wiki/xxx" --output out.txt
 
-  # 读取消息记录
-  python3 feishu_mcp_client.py --chat-id "oc_xxx" --target "张三" --output out.txt
+  # read chat messages
+  python3 feishu_mcp_client.py --chat-id "oc_xxx" --target "Zhang San" --output out.txt
 
-  # 列出某空间下的所有文档
+  # list docs in a wiki space
   python3 feishu_mcp_client.py --list-wiki --space-id "xxx"
 """
 
 from __future__ import annotations
 
-import os
-import sys
-import json
 import argparse
+import json
+import os
 import subprocess
+import sys
 from pathlib import Path
-from typing import Optional
 
 
 CONFIG_PATH = Path.home() / ".colleague-skill" / "feishu_config.json"
 
-
-# ─── 配置管理 ────────────────────────────────────────────────────────────────
 
 def load_config() -> dict:
     if CONFIG_PATH.exists():
@@ -56,20 +57,20 @@ def load_config() -> dict:
 def save_config(config: dict) -> None:
     CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
     CONFIG_PATH.write_text(json.dumps(config, indent=2))
-    print(f"配置已保存到 {CONFIG_PATH}")
+    print(f"configuration saved to {CONFIG_PATH}")
 
 
 def setup_config() -> None:
-    print("=== 飞书 MCP 配置 ===")
-    print("请前往飞书开放平台（open.feishu.cn）创建企业自建应用，获取以下信息：\n")
+    print("=== Feishu MCP Setup ===")
+    print("Create an enterprise internal app at open.feishu.cn and collect the following values.\n")
 
     app_id = input("App ID (cli_xxx): ").strip()
     app_secret = input("App Secret: ").strip()
 
-    print("\n配置方式选择：")
-    print("  [1] App Token（应用权限，需要在飞书后台开通对应权限）")
-    print("  [2] User Token（个人权限，能访问你本人有权限的所有内容，需要定期刷新）")
-    mode = input("选择 [1/2]，默认 1：").strip() or "1"
+    print("\nChoose token mode:")
+    print("  [1] App token (app-level permissions configured in Feishu)")
+    print("  [2] User token (accesses content the user can see, needs refresh over time)")
+    mode = input("Choose [1/2], default 1: ").strip() or "1"
 
     config = {
         "app_id": app_id,
@@ -78,22 +79,17 @@ def setup_config() -> None:
     }
 
     if mode == "2":
-        print("\n获取 User Token：飞书开放平台 → OAuth 2.0 → 获取 user_access_token")
-        user_token = input("User Access Token (u-xxx)：").strip()
+        print("\nGet a user token through Feishu Open Platform -> OAuth 2.0 -> user_access_token")
+        user_token = input("User Access Token (u-xxx): ").strip()
         config["user_token"] = user_token
-        print("注意：User Token 有效期约 2 小时，过期后需要重新配置")
+        print("Note: a user token typically expires after about 2 hours and must be refreshed.")
 
     save_config(config)
-    print("\n✅ 配置完成！")
+    print("\nsetup complete")
 
-
-# ─── MCP 调用封装 ─────────────────────────────────────────────────────────────
 
 def call_mcp(tool: str, params: dict, config: dict) -> dict:
-    """
-    通过 npx 调用 feishu-mcp 工具。
-    feishu-mcp 支持 stdio 模式，直接 JSON 通信。
-    """
+    """Call `feishu-mcp` through `npx` using stdio JSON-RPC."""
     env = os.environ.copy()
     env["FEISHU_APP_ID"] = config.get("app_id", "")
     env["FEISHU_APP_SECRET"] = config.get("app_secret", "")
@@ -101,15 +97,17 @@ def call_mcp(tool: str, params: dict, config: dict) -> dict:
     if config.get("mode") == "user" and config.get("user_token"):
         env["FEISHU_USER_ACCESS_TOKEN"] = config["user_token"]
 
-    payload = json.dumps({
-        "jsonrpc": "2.0",
-        "method": "tools/call",
-        "params": {
-            "name": tool,
-            "arguments": params,
-        },
-        "id": 1,
-    })
+    payload = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "method": "tools/call",
+            "params": {
+                "name": tool,
+                "arguments": params,
+            },
+            "id": 1,
+        }
+    )
 
     try:
         result = subprocess.run(
@@ -121,17 +119,18 @@ def call_mcp(tool: str, params: dict, config: dict) -> dict:
             timeout=30,
         )
         if result.returncode != 0:
-            raise RuntimeError(f"MCP 调用失败：{result.stderr}")
+            raise RuntimeError(f"MCP call failed: {result.stderr}")
         return json.loads(result.stdout)
     except FileNotFoundError:
-        print("错误：未找到 npx，请先安装 Node.js", file=sys.stderr)
-        print("安装 Feishu MCP：npm install -g feishu-mcp", file=sys.stderr)
+        print("error: `npx` was not found. Install Node.js first.", file=sys.stderr)
+        print("Then install Feishu MCP with: npm install -g feishu-mcp", file=sys.stderr)
         sys.exit(1)
 
 
 def extract_doc_token(url: str) -> tuple[str, str]:
-    """从飞书 URL 中提取文档 token 和类型"""
+    """Extract the document token and type from a Feishu URL."""
     import re
+
     patterns = [
         (r"/wiki/([A-Za-z0-9]+)", "wiki"),
         (r"/docx/([A-Za-z0-9]+)", "docx"),
@@ -140,16 +139,14 @@ def extract_doc_token(url: str) -> tuple[str, str]:
         (r"/base/([A-Za-z0-9]+)", "base"),
     ]
     for pattern, doc_type in patterns:
-        m = re.search(pattern, url)
-        if m:
-            return m.group(1), doc_type
-    raise ValueError(f"无法从 URL 解析文档 token：{url}")
+        match = re.search(pattern, url)
+        if match:
+            return match.group(1), doc_type
+    raise ValueError(f"could not extract a document token from URL: {url}")
 
-
-# ─── 功能函数 ─────────────────────────────────────────────────────────────────
 
 def fetch_doc_via_mcp(url: str, config: dict) -> str:
-    """通过 MCP 读取飞书文档或 Wiki"""
+    """Read a Feishu document or wiki page through MCP."""
     token, doc_type = extract_doc_token(url)
 
     if doc_type == "wiki":
@@ -159,20 +156,18 @@ def fetch_doc_via_mcp(url: str, config: dict) -> str:
     elif doc_type == "sheet":
         result = call_mcp("get_spreadsheet_content", {"spreadsheet_token": token}, config)
     else:
-        raise ValueError(f"不支持的文档类型：{doc_type}")
+        raise ValueError(f"unsupported document type: {doc_type}")
 
-    # 提取 MCP 返回的内容
     if "result" in result:
         content = result["result"]
         if isinstance(content, list):
-            # MCP tool result 格式
             for item in content:
                 if isinstance(item, dict) and item.get("type") == "text":
                     return item.get("text", "")
         elif isinstance(content, str):
             return content
     elif "error" in result:
-        raise RuntimeError(f"MCP 返回错误：{result['error']}")
+        raise RuntimeError(f"MCP returned an error: {result['error']}")
 
     return json.dumps(result, ensure_ascii=False, indent=2)
 
@@ -183,12 +178,12 @@ def fetch_messages_via_mcp(
     limit: int,
     config: dict,
 ) -> str:
-    """通过 MCP 读取群聊消息记录"""
+    """Read group-chat messages through MCP."""
     result = call_mcp(
         "get_chat_messages",
         {
             "chat_id": chat_id,
-            "page_size": min(limit, 50),  # 飞书 API 单次最多 50 条
+            "page_size": min(limit, 50),
         },
         config,
     )
@@ -203,46 +198,45 @@ def fetch_messages_via_mcp(
         except Exception:
             return raw
 
-    # 过滤目标人物
     if target_name:
         messages = [
-            m for m in messages
-            if target_name in str(m.get("sender", {}).get("name", ""))
+            message
+            for message in messages
+            if target_name in str(message.get("sender", {}).get("name", ""))
         ]
 
-    # 分类输出
-    long_msgs = [m for m in messages if len(str(m.get("content", ""))) > 50]
-    short_msgs = [m for m in messages if len(str(m.get("content", ""))) <= 50]
+    long_msgs = [message for message in messages if len(str(message.get("content", ""))) > 50]
+    short_msgs = [message for message in messages if len(str(message.get("content", ""))) <= 50]
 
     lines = [
-        "# 飞书消息记录（MCP 方案）",
-        f"群聊 ID：{chat_id}",
-        f"目标人物：{target_name or '全部'}",
-        f"共 {len(messages)} 条",
+        "# Feishu Messages (MCP)",
+        f"Chat ID: {chat_id}",
+        f"Target: {target_name or 'all'}",
+        f"Total messages: {len(messages)}",
         "",
         "---",
         "",
-        "## 长消息",
+        "## Long Messages",
         "",
     ]
-    for m in long_msgs:
-        sender = m.get("sender", {}).get("name", "")
-        content = m.get("content", "")
-        ts = m.get("create_time", "")
-        lines.append(f"[{ts}] {sender}：{content}")
+    for message in long_msgs:
+        sender = message.get("sender", {}).get("name", "")
+        content = message.get("content", "")
+        timestamp = message.get("create_time", "")
+        lines.append(f"[{timestamp}] {sender}: {content}")
         lines.append("")
 
-    lines += ["---", "", "## 日常消息", ""]
-    for m in short_msgs[:200]:
-        sender = m.get("sender", {}).get("name", "")
-        content = m.get("content", "")
-        lines.append(f"{sender}：{content}")
+    lines += ["---", "", "## Daily Messages", ""]
+    for message in short_msgs[:200]:
+        sender = message.get("sender", {}).get("name", "")
+        content = message.get("content", "")
+        lines.append(f"{sender}: {content}")
 
     return "\n".join(lines)
 
 
 def list_wiki_docs(space_id: str, config: dict) -> str:
-    """列出知识库空间下的所有文档"""
+    """List all docs inside a wiki space."""
     result = call_mcp("list_wiki_nodes", {"space_id": space_id}, config)
     raw = result.get("result", "")
     if isinstance(raw, str):
@@ -250,18 +244,16 @@ def list_wiki_docs(space_id: str, config: dict) -> str:
     return json.dumps(raw, ensure_ascii=False, indent=2)
 
 
-# ─── CLI ─────────────────────────────────────────────────────────────────────
-
 def main() -> None:
-    parser = argparse.ArgumentParser(description="飞书 MCP 客户端")
-    parser.add_argument("--setup", action="store_true", help="初始化配置（App ID / Secret）")
-    parser.add_argument("--url", help="飞书文档/Wiki/表格链接")
-    parser.add_argument("--chat-id", help="群聊 ID（oc_xxx 格式）")
-    parser.add_argument("--target", help="目标人物姓名")
-    parser.add_argument("--limit", type=int, default=500, help="最多获取消息数")
-    parser.add_argument("--list-wiki", action="store_true", help="列出知识库文档")
-    parser.add_argument("--space-id", help="知识库 Space ID")
-    parser.add_argument("--output", default=None, help="输出文件路径")
+    parser = argparse.ArgumentParser(description="Feishu MCP client")
+    parser.add_argument("--setup", action="store_true", help="initialize local configuration")
+    parser.add_argument("--url", help="Feishu doc / wiki / sheet URL")
+    parser.add_argument("--chat-id", help="chat ID (format: oc_xxx)")
+    parser.add_argument("--target", help="target person name")
+    parser.add_argument("--limit", type=int, default=500, help="maximum number of messages to fetch")
+    parser.add_argument("--list-wiki", action="store_true", help="list wiki documents")
+    parser.add_argument("--space-id", help="wiki space ID")
+    parser.add_argument("--output", default=None, help="output file path")
 
     args = parser.parse_args()
 
@@ -271,37 +263,34 @@ def main() -> None:
 
     config = load_config()
     if not config:
-        print("错误：尚未配置，请先运行：python3 feishu_mcp_client.py --setup", file=sys.stderr)
+        print("error: not configured yet. Run `python3 feishu_mcp_client.py --setup` first.", file=sys.stderr)
         sys.exit(1)
 
     content = ""
 
     if args.url:
-        print(f"通过 MCP 读取：{args.url}", file=sys.stderr)
+        print(f"reading via MCP: {args.url}", file=sys.stderr)
         content = fetch_doc_via_mcp(args.url, config)
-
     elif args.chat_id:
-        print(f"通过 MCP 读取消息：{args.chat_id}", file=sys.stderr)
+        print(f"reading chat via MCP: {args.chat_id}", file=sys.stderr)
         content = fetch_messages_via_mcp(
             args.chat_id,
             args.target or "",
             args.limit,
             config,
         )
-
     elif args.list_wiki:
         if not args.space_id:
-            print("错误：--list-wiki 需要 --space-id", file=sys.stderr)
+            print("error: --list-wiki requires --space-id", file=sys.stderr)
             sys.exit(1)
         content = list_wiki_docs(args.space_id, config)
-
     else:
         parser.print_help()
         return
 
     if args.output:
         Path(args.output).write_text(content, encoding="utf-8")
-        print(f"✅ 已保存到 {args.output}", file=sys.stderr)
+        print(f"saved to {args.output}", file=sys.stderr)
     else:
         print(content)
 

--- a/tools/feishu_parser.py
+++ b/tools/feishu_parser.py
@@ -1,42 +1,34 @@
 #!/usr/bin/env python3
 """
-飞书消息导出 JSON 解析器
+Feishu message export parser.
 
-支持的导出格式：
-1. 飞书官方导出（群聊记录）：通常为 JSON 数组，每条消息包含 sender、content、timestamp
-2. 手动整理的 TXT 格式（每行：时间 发送人：内容）
+Supported input formats:
+1. Official Feishu JSON exports, usually arrays of messages with sender/content/timestamp
+2. Manually prepared TXT logs, one line per message
 
-用法：
-    python feishu_parser.py --file messages.json --target "张三" --output output.txt
-    python feishu_parser.py --file messages.txt --target "张三" --output output.txt
+Usage:
+    python feishu_parser.py --file messages.json --target "Zhang San" --output output.txt
+    python feishu_parser.py --file messages.txt --target "Zhang San" --output output.txt
 """
 
+import argparse
 import json
 import re
 import sys
-import argparse
 from pathlib import Path
-from datetime import datetime
 
 
 def parse_feishu_json(file_path: str, target_name: str) -> list[dict]:
-    """解析飞书官方导出的 JSON 格式消息"""
+    """Parse Feishu's exported JSON message format."""
     with open(file_path, "r", encoding="utf-8") as f:
         data = json.load(f)
 
     messages = []
 
-    # 兼容多种 JSON 结构
     if isinstance(data, list):
         raw_messages = data
     elif isinstance(data, dict):
-        # 可能在 data.messages 或 data.records 等字段下
-        raw_messages = (
-            data.get("messages")
-            or data.get("records")
-            or data.get("data")
-            or []
-        )
+        raw_messages = data.get("messages") or data.get("records") or data.get("data") or []
     else:
         return []
 
@@ -62,40 +54,38 @@ def parse_feishu_json(file_path: str, target_name: str) -> list[dict]:
             or ""
         )
 
-        # content 可能是嵌套结构
         if isinstance(content, dict):
             content = content.get("text") or content.get("content") or str(content)
         if isinstance(content, list):
             content = " ".join(
-                c.get("text", "") if isinstance(c, dict) else str(c)
-                for c in content
+                item.get("text", "") if isinstance(item, dict) else str(item)
+                for item in content
             )
 
-        # 过滤：只保留目标人发送的消息
         if target_name and target_name not in str(sender):
             continue
 
-        # 过滤：跳过系统消息、表情包、撤回消息
         if not content or content.strip() in ["[图片]", "[文件]", "[撤回了一条消息]", "[语音]"]:
             continue
 
-        messages.append({
-            "sender": str(sender),
-            "content": str(content).strip(),
-            "timestamp": str(timestamp),
-        })
+        messages.append(
+            {
+                "sender": str(sender),
+                "content": str(content).strip(),
+                "timestamp": str(timestamp),
+            }
+        )
 
     return messages
 
 
 def parse_feishu_txt(file_path: str, target_name: str) -> list[dict]:
-    """解析手动整理的 TXT 格式消息（格式：时间 发送人：内容）"""
+    """Parse a plain-text Feishu chat log in `time sender: message` format."""
     messages = []
 
     with open(file_path, "r", encoding="utf-8") as f:
         lines = f.readlines()
 
-    # 匹配格式：2024-01-01 10:00 张三：消息内容
     pattern = re.compile(
         r"^(?P<time>\d{4}[-/]\d{1,2}[-/]\d{1,2}[\s\d:]*)\s+(?P<sender>.+?)[:：]\s*(?P<content>.+)$"
     )
@@ -105,49 +95,70 @@ def parse_feishu_txt(file_path: str, target_name: str) -> list[dict]:
         if not line:
             continue
 
-        m = pattern.match(line)
-        if m:
-            sender = m.group("sender").strip()
-            content = m.group("content").strip()
-            timestamp = m.group("time").strip()
+        match = pattern.match(line)
+        if match:
+            sender = match.group("sender").strip()
+            content = match.group("content").strip()
+            timestamp = match.group("time").strip()
 
             if target_name and target_name not in sender:
                 continue
             if not content:
                 continue
 
-            messages.append({
-                "sender": sender,
-                "content": content,
-                "timestamp": timestamp,
-            })
+            messages.append(
+                {
+                    "sender": sender,
+                    "content": content,
+                    "timestamp": timestamp,
+                }
+            )
         else:
-            # 没有匹配格式，检查是否包含目标人名
             if target_name and target_name in line:
-                messages.append({
-                    "sender": target_name,
-                    "content": line,
-                    "timestamp": "",
-                })
+                messages.append(
+                    {
+                        "sender": target_name,
+                        "content": line,
+                        "timestamp": "",
+                    }
+                )
 
     return messages
 
 
 def extract_key_content(messages: list[dict]) -> dict:
     """
-    对消息进行分类提取，区分：
-    - 长消息（>50字）：可能包含观点、方案、技术判断
-    - 决策类回复：包含"同意""不行""觉得""建议"等关键词
-    - 日常沟通：其他消息
+    Split messages into:
+    - long messages (>50 chars): likely proposals, opinions, technical judgment
+    - decision messages: contain explicit decision keywords
+    - daily communication: everything else
     """
     long_messages = []
     decision_messages = []
     daily_messages = []
 
     decision_keywords = [
-        "同意", "不行", "觉得", "建议", "应该", "不应该", "可以", "不可以",
-        "方案", "思路", "考虑", "决定", "确认", "拒绝", "推进", "暂缓",
-        "没问题", "有问题", "风险", "评估", "判断"
+        "同意",
+        "不行",
+        "觉得",
+        "建议",
+        "应该",
+        "不应该",
+        "可以",
+        "不可以",
+        "方案",
+        "思路",
+        "考虑",
+        "决定",
+        "确认",
+        "拒绝",
+        "推进",
+        "暂缓",
+        "没问题",
+        "有问题",
+        "风险",
+        "评估",
+        "判断",
     ]
 
     for msg in messages:
@@ -155,7 +166,7 @@ def extract_key_content(messages: list[dict]) -> dict:
 
         if len(content) > 50:
             long_messages.append(msg)
-        elif any(kw in content for kw in decision_keywords):
+        elif any(keyword in content for keyword in decision_keywords):
             decision_messages.append(msg)
         else:
             daily_messages.append(msg)
@@ -169,15 +180,15 @@ def extract_key_content(messages: list[dict]) -> dict:
 
 
 def format_output(target_name: str, extracted: dict) -> str:
-    """格式化输出，供 AI 分析使用"""
+    """Format extracted Feishu messages for downstream AI analysis."""
     lines = [
-        f"# 飞书消息提取结果",
-        f"目标人物：{target_name}",
-        f"总消息数：{extracted['total_count']}",
+        "# Feishu Message Extraction",
+        f"Target: {target_name}",
+        f"Total messages: {extracted['total_count']}",
         "",
         "---",
         "",
-        "## 长消息（观点/方案类，权重最高）",
+        "## Long Messages (proposals / opinions, highest weight)",
         "",
     ]
 
@@ -189,7 +200,7 @@ def format_output(target_name: str, extracted: dict) -> str:
     lines += [
         "---",
         "",
-        "## 决策类回复",
+        "## Decision Messages",
         "",
     ]
 
@@ -201,11 +212,10 @@ def format_output(target_name: str, extracted: dict) -> str:
     lines += [
         "---",
         "",
-        "## 日常沟通（风格参考）",
+        "## Daily Communication (style reference)",
         "",
     ]
 
-    # 日常消息只取前 100 条，避免太长
     for msg in extracted["daily_messages"][:100]:
         ts = f"[{msg['timestamp']}] " if msg["timestamp"] else ""
         lines.append(f"{ts}{msg['content']}")
@@ -213,28 +223,31 @@ def format_output(target_name: str, extracted: dict) -> str:
     return "\n".join(lines)
 
 
-def main():
-    parser = argparse.ArgumentParser(description="解析飞书消息导出文件")
-    parser.add_argument("--file", required=True, help="输入文件路径（.json 或 .txt）")
-    parser.add_argument("--target", required=True, help="目标人物姓名（只提取此人发出的消息）")
-    parser.add_argument("--output", default=None, help="输出文件路径（默认打印到 stdout）")
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Parse Feishu message export files")
+    parser.add_argument("--file", required=True, help="input file path (.json or .txt)")
+    parser.add_argument(
+        "--target",
+        required=True,
+        help="target person name (only messages sent by this person are extracted)",
+    )
+    parser.add_argument("--output", default=None, help="output file path (defaults to stdout)")
 
     args = parser.parse_args()
 
     file_path = Path(args.file)
     if not file_path.exists():
-        print(f"错误：文件不存在 {file_path}", file=sys.stderr)
+        print(f"error: file does not exist: {file_path}", file=sys.stderr)
         sys.exit(1)
 
-    # 根据文件类型选择解析器
     if file_path.suffix.lower() == ".json":
         messages = parse_feishu_json(str(file_path), args.target)
     else:
         messages = parse_feishu_txt(str(file_path), args.target)
 
     if not messages:
-        print(f"警告：未找到 '{args.target}' 发出的消息", file=sys.stderr)
-        print("提示：请检查目标姓名是否与文件中的发送人名称一致", file=sys.stderr)
+        print(f"warning: no messages found from '{args.target}'", file=sys.stderr)
+        print("hint: check whether the target name matches the sender field", file=sys.stderr)
 
     extracted = extract_key_content(messages)
     output = format_output(args.target, extracted)
@@ -242,7 +255,7 @@ def main():
     if args.output:
         with open(args.output, "w", encoding="utf-8") as f:
             f.write(output)
-        print(f"已输出到 {args.output}，共 {len(messages)} 条消息")
+        print(f"written to {args.output}; extracted {len(messages)} messages")
     else:
         print(output)
 

--- a/tools/skill_writer.py
+++ b/tools/skill_writer.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 """
-Skill 文件写入器
+Skill file writer.
 
-负责将生成的 work.md、persona.md 写入到正确的目录结构，
-并生成 meta.json 和完整的 SKILL.md。
+Writes generated `work.md` and `persona.md` files into the expected directory
+structure, creates `meta.json`, and assembles the full `SKILL.md`.
 
-用法：
+Usage:
     python3 skill_writer.py --action create --slug zhangsan --meta meta.json \
         --work work_content.md --persona persona_content.md \
         --base-dir ./colleagues
@@ -19,16 +19,97 @@ Skill 文件写入器
 
 from __future__ import annotations
 
-import json
-import shutil
 import argparse
+import json
+import re
+import shutil
 import sys
-from pathlib import Path
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Optional
 
 
-SKILL_MD_TEMPLATE = """\
+LANG_CONFIG = {
+    "en": {
+        "identity_fallback": "colleague",
+        "mbti_separator": ", MBTI ",
+        "skill_md_template": """\
+---
+name: colleague_{slug}
+description: {name}, {identity}
+user-invocable: true
+---
+
+# {name}
+
+{identity}
+
+---
+
+## PART A: Work Capabilities
+
+{work_content}
+
+---
+
+## PART B: Persona
+
+{persona_content}
+
+---
+
+## Execution Rules
+
+When you receive any task or question:
+
+1. **Let PART B decide first**: whether to take the task, and with what attitude
+2. **Then let PART A execute**: use the person's technical skills and working style to complete the task
+3. **Keep PART B's communication style in the output**: wording, tone, and sentence patterns
+
+**PART B Layer 0 rules always take priority and must never be violated.**
+""",
+        "work_only_description": "{name}'s work capabilities (Work only, no Persona)",
+        "persona_only_description": "{name}'s persona (Persona only, no Work capabilities)",
+        "correction_section": "## Correction Log",
+        "correction_placeholder": "(No entries yet)",
+        "default_scene": "general",
+        "correction_line": "- [Scene: {scene}] Should not {wrong}; should {correct}",
+        "list_empty": "No colleague skills created yet",
+        "list_header": "Created {count} colleague skills:\n",
+        "list_item": "  [{slug}]  {name} - {identity}",
+        "list_meta": "    Version: {version}  Corrections: {corrections_count}  Updated: {updated}",
+        "reviewer_list_empty": "No reviewer skills created yet",
+        "reviewer_list_header": "Created {count} reviewer skills:\n",
+        "reviewer_list_meta": "    Type: {reviewer_type}  Version: {version}  Corrections: {corrections_count}  Updated: {updated}",
+        "unknown_date": "unknown",
+        "parser_description": "Skill file writer",
+        "slug_help": "colleague slug (used as the directory name)",
+        "name_help": "colleague name",
+        "meta_help": "path to meta.json",
+        "work_help": "path to the work.md content file",
+        "persona_help": "path to the persona.md content file",
+        "reviewer_type_help": "reviewer type (pr or design)",
+        "review_help": "path to the review.md content file",
+        "examples_help": "path to the examples.md content file",
+        "work_patch_help": "path to the incremental work.md patch file",
+        "persona_patch_help": "path to the incremental persona.md patch file",
+        "base_dir_help": "root directory for colleague skills (default: ./colleagues)",
+        "create_missing_name": "error: create requires --slug or --name",
+        "create_reviewer_missing_type": "error: create-reviewer requires --reviewer-type",
+        "create_reviewer_missing_review": "error: create-reviewer requires --review",
+        "create_reviewer_missing_examples": "error: create-reviewer requires --examples",
+        "created_skill": "Created skill: {skill_dir}",
+        "created_reviewer": "Created {reviewer_label}: {skill_dir}",
+        "trigger_phrase": "Trigger: /{slug}",
+        "reviewer_trigger_phrase": "Trigger: /{trigger}",
+        "update_missing_slug": "error: update requires --slug",
+        "skill_dir_missing": "error: could not find skill directory {skill_dir}",
+        "updated_skill": "Updated skill to {version}: {skill_dir}",
+    },
+    "zh": {
+        "identity_fallback": "同事",
+        "mbti_separator": "，MBTI ",
+        "skill_md_template": """\
 ---
 name: colleague_{slug}
 description: {name}，{identity}
@@ -62,40 +143,175 @@ user-invocable: true
 3. **输出时保持 PART B 的表达风格**：你说话的方式、用词习惯、句式
 
 **PART B 的 Layer 0 规则永远优先，任何情况下不得违背。**
-"""
+""",
+        "work_only_description": "{name} 的工作能力（仅 Work，无 Persona）",
+        "persona_only_description": "{name} 的人物性格（仅 Persona，无工作能力）",
+        "correction_section": "## Correction 记录",
+        "correction_placeholder": "（暂无记录）",
+        "default_scene": "通用",
+        "correction_line": "- [{scene}] 不应该 {wrong}，应该 {correct}",
+        "list_empty": "暂无已创建的同事 Skill",
+        "list_header": "已创建 {count} 个同事 Skill：\n",
+        "list_item": "  [{slug}]  {name} - {identity}",
+        "list_meta": "    版本: {version}  纠正次数: {corrections_count}  更新: {updated}",
+        "reviewer_list_empty": "暂无已创建的审查者 Skill",
+        "reviewer_list_header": "已创建 {count} 个审查者 Skill：\n",
+        "reviewer_list_meta": "    类型: {reviewer_type}  版本: {version}  纠正次数: {corrections_count}  更新: {updated}",
+        "unknown_date": "未知",
+        "parser_description": "Skill 文件写入器",
+        "slug_help": "同事 slug（用于目录名）",
+        "name_help": "同事姓名",
+        "meta_help": "meta.json 文件路径",
+        "work_help": "work.md 内容文件路径",
+        "persona_help": "persona.md 内容文件路径",
+        "reviewer_type_help": "审查者类型（pr 或 design）",
+        "review_help": "review.md 内容文件路径",
+        "examples_help": "examples.md 内容文件路径",
+        "work_patch_help": "work.md 增量更新内容文件路径",
+        "persona_patch_help": "persona.md 增量更新内容文件路径",
+        "base_dir_help": "同事 Skill 根目录（默认：./colleagues）",
+        "create_missing_name": "错误：create 操作需要 --slug 或 --name",
+        "create_reviewer_missing_type": "错误：create-reviewer 操作需要 --reviewer-type",
+        "create_reviewer_missing_review": "错误：create-reviewer 操作需要 --review",
+        "create_reviewer_missing_examples": "错误：create-reviewer 操作需要 --examples",
+        "created_skill": "✅ Skill 已创建：{skill_dir}",
+        "created_reviewer": "✅ 已创建 {reviewer_label}：{skill_dir}",
+        "trigger_phrase": "   触发词：/{slug}",
+        "reviewer_trigger_phrase": "   触发词：/{trigger}",
+        "update_missing_slug": "错误：update 操作需要 --slug",
+        "skill_dir_missing": "错误：找不到 Skill 目录 {skill_dir}",
+        "updated_skill": "✅ Skill 已更新到 {version}：{skill_dir}",
+    },
+}
+
+
+REVIEWER_LANG_CONFIG = {
+    "en": {
+        "identity_separator": " | ",
+        "review_rules_heading": "## Review Rules",
+        "review_examples_heading": "## Review Examples",
+        "execution_heading": "## Execution Rules",
+        "preserve_style_rule": "Preserve the reviewer's severity, framing, and phrasing style.",
+        "ask_for_context_rule": "Ask for missing context when the material is insufficient to make a confident review call.",
+        "no_implementation_rule": "Do not switch into implementation mode unless the user explicitly requests separate implementation help.",
+    },
+    "zh": {
+        "identity_separator": "｜",
+        "review_rules_heading": "## 评审规则",
+        "review_examples_heading": "## 评审示例",
+        "execution_heading": "## 执行规则",
+        "preserve_style_rule": "保持该审查者的严重级别判断、表达框架和措辞风格。",
+        "ask_for_context_rule": "当材料不足以做出可靠评审结论时，先要求补充上下文。",
+        "no_implementation_rule": "除非用户明确要求单独的实现帮助，否则不要切换到实现模式。",
+    },
+}
+
+
+REVIEWER_CONFIG = {
+    "pr": {
+        "skill_name_prefix": "pr-reviewer",
+        "title": {"en": "PR Reviewer", "zh": "PR 审查者"},
+        "description": {
+            "en": "{name}, review-only clone for PR/code review",
+            "zh": "{name}，仅用于 PR/代码评审的克隆",
+        },
+        "identity_suffix": {
+            "en": "review-only PR/code reviewer",
+            "zh": "仅用于 PR/代码评审",
+        },
+        "stay_in_domain_rule": {
+            "en": "Stay in PR/code review mode only.",
+            "zh": "只保持在 PR/代码评审模式。",
+        },
+        "apply_rule": {
+            "en": "Review pull requests, diffs, tests, and release risk using the heuristics above.",
+            "zh": "使用上述启发式方法评审 PR、代码 diff、测试和发布风险。",
+        },
+    },
+    "design": {
+        "skill_name_prefix": "design-reviewer",
+        "title": {"en": "Design Reviewer", "zh": "设计审查者"},
+        "description": {
+            "en": "{name}, review-only clone for RFC/design/architecture review",
+            "zh": "{name}，仅用于 RFC/设计/架构评审的克隆",
+        },
+        "identity_suffix": {
+            "en": "review-only design/architecture reviewer",
+            "zh": "仅用于设计/架构评审",
+        },
+        "stay_in_domain_rule": {
+            "en": "Stay in RFC/design/architecture review mode only.",
+            "zh": "只保持在 RFC/设计/架构评审模式。",
+        },
+        "apply_rule": {
+            "en": "Review problem framing, contracts, tradeoffs, rollout, and reversibility using the heuristics above.",
+            "zh": "使用上述启发式方法评审问题定义、契约、权衡、发布方案和可回滚性。",
+        },
+    },
+}
+
+
+def normalize_language(value: Optional[str]) -> str:
+    if not value:
+        return "en"
+    return "zh" if str(value).lower().startswith("zh") else "en"
+
+
+def get_language(meta: dict) -> str:
+    return normalize_language(meta.get("language") or meta.get("lang"))
+
+
+def render_skill_md(
+    language: str,
+    slug: str,
+    name: str,
+    identity: str,
+    work_content: str,
+    persona_content: str,
+) -> str:
+    template = LANG_CONFIG[language]["skill_md_template"]
+    return template.format(
+        slug=slug,
+        name=name,
+        identity=identity,
+        work_content=work_content,
+        persona_content=persona_content,
+    )
 
 
 def slugify(name: str) -> str:
     """
-    将姓名转为 slug。
-    优先尝试 pypinyin（如已安装），否则 fallback 到简单处理。
+    Convert a human name into a slug.
+
+    Prefer `pypinyin` when available so Chinese names can become readable slugs.
+    Fall back to a simple ASCII-only conversion otherwise.
     """
-    # 尝试用 pypinyin 转拼音
     try:
         from pypinyin import lazy_pinyin
+
         parts = lazy_pinyin(name)
         slug = "_".join(parts)
     except ImportError:
-        # fallback：保留 ASCII 字母数字，中文直接去掉
         import unicodedata
+
         result = []
         for char in name.lower():
-            cat = unicodedata.category(char)
             if char.isascii() and (char.isalnum() or char in ("-", "_")):
                 result.append(char)
             elif char == " ":
                 result.append("_")
-            # 中文字符跳过（无 pypinyin 时无法转换）
+            else:
+                cat = unicodedata.category(char)
+                if cat.startswith("L") or cat.startswith("N"):
+                    continue
         slug = "".join(result)
 
-    # 清理：去掉连续下划线，首尾下划线
-    import re
     slug = re.sub(r"_+", "_", slug).strip("_")
     return slug if slug else "colleague"
 
 
-def build_identity_string(meta: dict) -> str:
-    """从 meta 构建身份描述字符串"""
+def build_identity_string(meta: dict, language: str, default_value: Optional[str] = None) -> str:
+    """Build a compact identity string from `meta`."""
     profile = meta.get("profile", {})
     parts = []
 
@@ -110,13 +326,102 @@ def build_identity_string(meta: dict) -> str:
     if role:
         parts.append(role)
 
-    identity = " ".join(parts) if parts else "同事"
+    config = LANG_CONFIG[language]
+    identity = " ".join(parts) if parts else (default_value or config["identity_fallback"])
 
     mbti = profile.get("mbti", "")
     if mbti:
-        identity += f"，MBTI {mbti}"
+        identity += f"{config['mbti_separator']}{mbti}"
 
     return identity
+
+
+def get_reviewer_skill_name(reviewer_type: str, slug: str) -> str:
+    return f"{REVIEWER_CONFIG[reviewer_type]['skill_name_prefix']}-{slug}"
+
+
+def get_reviewer_label(reviewer_type: str, language: str) -> str:
+    return REVIEWER_CONFIG[reviewer_type]["title"][language]
+
+
+def build_reviewer_identity(meta: dict, language: str, reviewer_type: str) -> str:
+    reviewer_config = REVIEWER_CONFIG[reviewer_type]
+    reviewer_lang = REVIEWER_LANG_CONFIG[language]
+    base_identity = build_identity_string(
+        meta,
+        language,
+        default_value=reviewer_config["title"][language],
+    )
+    suffix = reviewer_config["identity_suffix"][language]
+
+    if base_identity == reviewer_config["title"][language]:
+        return suffix
+    return f"{base_identity}{reviewer_lang['identity_separator']}{suffix}"
+
+
+def render_reviewer_skill_md(
+    language: str,
+    reviewer_type: str,
+    slug: str,
+    name: str,
+    identity: str,
+    review_content: str,
+    examples_content: str,
+) -> str:
+    reviewer_config = REVIEWER_CONFIG[reviewer_type]
+    reviewer_lang = REVIEWER_LANG_CONFIG[language]
+    execution_rules = [
+        reviewer_config["stay_in_domain_rule"][language],
+        reviewer_config["apply_rule"][language],
+        reviewer_lang["preserve_style_rule"],
+        reviewer_lang["ask_for_context_rule"],
+        reviewer_lang["no_implementation_rule"],
+    ]
+    rendered_rules = "\n".join(
+        f"{index}. {rule}" for index, rule in enumerate(execution_rules, start=1)
+    )
+
+    return """\
+---
+name: {skill_name}
+description: {description}
+user-invocable: true
+---
+
+# {name} - {title}
+
+{identity}
+
+---
+
+{review_rules_heading}
+
+{review_content}
+
+---
+
+{review_examples_heading}
+
+{examples_content}
+
+---
+
+{execution_heading}
+
+{execution_rules}
+""".format(
+        skill_name=get_reviewer_skill_name(reviewer_type, slug),
+        description=reviewer_config["description"][language].format(name=name),
+        name=name,
+        title=reviewer_config["title"][language],
+        identity=identity,
+        review_rules_heading=reviewer_lang["review_rules_heading"],
+        review_content=review_content.strip(),
+        review_examples_heading=reviewer_lang["review_examples_heading"],
+        examples_content=examples_content.strip(),
+        execution_heading=reviewer_lang["execution_heading"],
+        execution_rules=rendered_rules,
+    )
 
 
 def create_skill(
@@ -126,28 +431,26 @@ def create_skill(
     work_content: str,
     persona_content: str,
 ) -> Path:
-    """创建新的同事 Skill 目录结构"""
+    """Create a new colleague skill directory structure."""
+    language = get_language(meta)
+    config = LANG_CONFIG[language]
 
     skill_dir = base_dir / slug
     skill_dir.mkdir(parents=True, exist_ok=True)
 
-    # 创建子目录
     (skill_dir / "versions").mkdir(exist_ok=True)
     (skill_dir / "knowledge" / "docs").mkdir(parents=True, exist_ok=True)
     (skill_dir / "knowledge" / "messages").mkdir(parents=True, exist_ok=True)
     (skill_dir / "knowledge" / "emails").mkdir(parents=True, exist_ok=True)
 
-    # 写入 work.md
     (skill_dir / "work.md").write_text(work_content, encoding="utf-8")
-
-    # 写入 persona.md
     (skill_dir / "persona.md").write_text(persona_content, encoding="utf-8")
 
-    # 生成并写入 SKILL.md
     name = meta.get("name", slug)
-    identity = build_identity_string(meta)
+    identity = build_identity_string(meta, language)
 
-    skill_md = SKILL_MD_TEMPLATE.format(
+    skill_md = render_skill_md(
+        language=language,
         slug=slug,
         name=name,
         identity=identity,
@@ -156,29 +459,79 @@ def create_skill(
     )
     (skill_dir / "SKILL.md").write_text(skill_md, encoding="utf-8")
 
-    # 写入 work-only skill
     work_only = (
         f"---\nname: colleague_{slug}_work\n"
-        f"description: {name} 的工作能力（仅 Work，无 Persona）\n"
+        f"description: {config['work_only_description'].format(name=name)}\n"
         f"user-invocable: true\n---\n\n{work_content}\n"
     )
     (skill_dir / "work_skill.md").write_text(work_only, encoding="utf-8")
 
-    # 写入 persona-only skill
     persona_only = (
         f"---\nname: colleague_{slug}_persona\n"
-        f"description: {name} 的人物性格（仅 Persona，无工作能力）\n"
+        f"description: {config['persona_only_description'].format(name=name)}\n"
         f"user-invocable: true\n---\n\n{persona_content}\n"
     )
     (skill_dir / "persona_skill.md").write_text(persona_only, encoding="utf-8")
 
-    # 写入 meta.json
     now = datetime.now(timezone.utc).isoformat()
     meta["slug"] = slug
     meta.setdefault("created_at", now)
     meta["updated_at"] = now
     meta["version"] = "v1"
     meta.setdefault("corrections_count", 0)
+    meta.setdefault("language", language)
+
+    (skill_dir / "meta.json").write_text(
+        json.dumps(meta, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    return skill_dir
+
+
+def create_reviewer_skill(
+    base_dir: Path,
+    reviewer_type: str,
+    slug: str,
+    meta: dict,
+    review_content: str,
+    examples_content: str,
+) -> Path:
+    """Create a new review-only skill directory structure."""
+    language = get_language(meta)
+
+    skill_dir = base_dir / slug
+    skill_dir.mkdir(parents=True, exist_ok=True)
+
+    (skill_dir / "versions").mkdir(exist_ok=True)
+    (skill_dir / "knowledge").mkdir(exist_ok=True)
+
+    (skill_dir / "review.md").write_text(review_content, encoding="utf-8")
+    (skill_dir / "examples.md").write_text(examples_content, encoding="utf-8")
+
+    name = meta.get("name", slug)
+    identity = build_reviewer_identity(meta, language, reviewer_type)
+    skill_md = render_reviewer_skill_md(
+        language=language,
+        reviewer_type=reviewer_type,
+        slug=slug,
+        name=name,
+        identity=identity,
+        review_content=review_content,
+        examples_content=examples_content,
+    )
+    (skill_dir / "SKILL.md").write_text(skill_md, encoding="utf-8")
+
+    now = datetime.now(timezone.utc).isoformat()
+    meta["slug"] = slug
+    meta["reviewer_type"] = reviewer_type
+    meta.setdefault("created_at", now)
+    meta["updated_at"] = now
+    meta["version"] = "v1"
+    meta.setdefault("corrections_count", 0)
+    meta.setdefault("knowledge_sources", [])
+    meta.setdefault("profile", {})
+    meta.setdefault("language", language)
 
     (skill_dir / "meta.json").write_text(
         json.dumps(meta, ensure_ascii=False, indent=2),
@@ -194,10 +547,12 @@ def update_skill(
     persona_patch: Optional[str] = None,
     correction: Optional[dict] = None,
 ) -> str:
-    """更新现有 Skill，先存档当前版本，再写入更新"""
-
+    """Update an existing skill, archiving the current version first."""
     meta_path = skill_dir / "meta.json"
     meta = json.loads(meta_path.read_text(encoding="utf-8"))
+
+    language = get_language(meta)
+    config = LANG_CONFIG[language]
 
     current_version = meta.get("version", "v1")
     try:
@@ -206,7 +561,6 @@ def update_skill(
         version_num = 2
     new_version = f"v{version_num}"
 
-    # 存档当前版本
     version_dir = skill_dir / "versions" / current_version
     version_dir.mkdir(parents=True, exist_ok=True)
     for fname in ("SKILL.md", "work.md", "persona.md"):
@@ -214,48 +568,56 @@ def update_skill(
         if src.exists():
             shutil.copy2(src, version_dir / fname)
 
-    # 应用 work patch
     if work_patch:
         current_work = (skill_dir / "work.md").read_text(encoding="utf-8")
         new_work = current_work + "\n\n" + work_patch
         (skill_dir / "work.md").write_text(new_work, encoding="utf-8")
 
-    # 应用 persona patch 或 correction
     if persona_patch or correction:
         current_persona = (skill_dir / "persona.md").read_text(encoding="utf-8")
 
         if correction:
-            correction_line = (
-                f"\n- [{correction.get('scene', '通用')}] "
-                f"不应该 {correction['wrong']}，应该 {correction['correct']}"
+            scene = correction.get("scene", config["default_scene"])
+            correction_line = config["correction_line"].format(
+                scene=scene,
+                wrong=correction["wrong"],
+                correct=correction["correct"],
             )
-            target = "## Correction 记录"
+            section_candidates = ("## Correction Log", "## Correction 记录")
+            placeholder_candidates = ("\n\n(No entries yet)", "\n\n（暂无记录）")
+
+            target = next(
+                (section for section in section_candidates if section in current_persona),
+                config["correction_section"],
+            )
+
             if target in current_persona:
                 insert_pos = current_persona.index(target) + len(target)
-                # 跳过紧跟的空行和"暂无"占位行
                 rest = current_persona[insert_pos:]
-                skip = "\n\n（暂无记录）"
-                if rest.startswith(skip):
-                    rest = rest[len(skip):]
-                new_persona = current_persona[:insert_pos] + correction_line + rest
+                for placeholder in placeholder_candidates:
+                    if rest.startswith(placeholder):
+                        rest = rest[len(placeholder):]
+                        break
+                new_persona = current_persona[:insert_pos] + "\n\n" + correction_line + rest
             else:
                 new_persona = (
                     current_persona
-                    + f"\n\n## Correction 记录\n{correction_line}\n"
+                    + f"\n\n{config['correction_section']}\n\n{correction_line}\n"
                 )
+
             meta["corrections_count"] = meta.get("corrections_count", 0) + 1
         else:
             new_persona = current_persona + "\n\n" + persona_patch
 
         (skill_dir / "persona.md").write_text(new_persona, encoding="utf-8")
 
-    # 重新生成 SKILL.md
     work_content = (skill_dir / "work.md").read_text(encoding="utf-8")
     persona_content = (skill_dir / "persona.md").read_text(encoding="utf-8")
     name = meta.get("name", skill_dir.name)
-    identity = build_identity_string(meta)
+    identity = build_identity_string(meta, language)
 
-    skill_md = SKILL_MD_TEMPLATE.format(
+    skill_md = render_skill_md(
+        language=language,
         slug=skill_dir.name,
         name=name,
         identity=identity,
@@ -264,7 +626,6 @@ def update_skill(
     )
     (skill_dir / "SKILL.md").write_text(skill_md, encoding="utf-8")
 
-    # 更新 meta
     meta["version"] = new_version
     meta["updated_at"] = datetime.now(timezone.utc).isoformat()
     meta_path.write_text(json.dumps(meta, ensure_ascii=False, indent=2), encoding="utf-8")
@@ -272,12 +633,12 @@ def update_skill(
     return new_version
 
 
-def list_colleagues(base_dir: Path) -> list:
-    """列出所有已创建的同事 Skill"""
-    colleagues = []
+def list_skills(base_dir: Path) -> list:
+    """List all created skills under a base directory."""
+    skills = []
 
     if not base_dir.exists():
-        return colleagues
+        return skills
 
     for skill_dir in sorted(base_dir.iterdir()):
         if not skill_dir.is_dir():
@@ -291,52 +652,110 @@ def list_colleagues(base_dir: Path) -> list:
         except Exception:
             continue
 
-        colleagues.append({
-            "slug": meta.get("slug", skill_dir.name),
-            "name": meta.get("name", skill_dir.name),
-            "identity": build_identity_string(meta),
-            "version": meta.get("version", "v1"),
-            "updated_at": meta.get("updated_at", ""),
-            "corrections_count": meta.get("corrections_count", 0),
-        })
+        language = get_language(meta)
+        reviewer_type = meta.get("reviewer_type")
+        identity = (
+            build_reviewer_identity(meta, language, reviewer_type)
+            if reviewer_type in REVIEWER_CONFIG
+            else build_identity_string(meta, language)
+        )
+        skills.append(
+            {
+                "slug": meta.get("slug", skill_dir.name),
+                "name": meta.get("name", skill_dir.name),
+                "identity": identity,
+                "version": meta.get("version", "v1"),
+                "updated_at": meta.get("updated_at", ""),
+                "corrections_count": meta.get("corrections_count", 0),
+                "language": language,
+                "reviewer_type": reviewer_type,
+                "reviewer_label": (
+                    get_reviewer_label(reviewer_type, language)
+                    if reviewer_type in REVIEWER_CONFIG
+                    else None
+                ),
+            }
+        )
 
-    return colleagues
+    return skills
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Skill 文件写入器")
-    parser.add_argument("--action", required=True, choices=["create", "update", "list"])
-    parser.add_argument("--slug", help="同事 slug（用于目录名）")
-    parser.add_argument("--name", help="同事姓名")
-    parser.add_argument("--meta", help="meta.json 文件路径")
-    parser.add_argument("--work", help="work.md 内容文件路径")
-    parser.add_argument("--persona", help="persona.md 内容文件路径")
-    parser.add_argument("--work-patch", help="work.md 增量更新内容文件路径")
-    parser.add_argument("--persona-patch", help="persona.md 增量更新内容文件路径")
+    parser = argparse.ArgumentParser(description=LANG_CONFIG["en"]["parser_description"])
+    parser.add_argument(
+        "--action",
+        required=True,
+        choices=["create", "update", "list", "create-reviewer"],
+    )
+    parser.add_argument("--slug", help=LANG_CONFIG["en"]["slug_help"])
+    parser.add_argument("--name", help=LANG_CONFIG["en"]["name_help"])
+    parser.add_argument("--meta", help=LANG_CONFIG["en"]["meta_help"])
+    parser.add_argument("--work", help=LANG_CONFIG["en"]["work_help"])
+    parser.add_argument("--persona", help=LANG_CONFIG["en"]["persona_help"])
+    parser.add_argument(
+        "--reviewer-type",
+        choices=sorted(REVIEWER_CONFIG),
+        help=LANG_CONFIG["en"]["reviewer_type_help"],
+    )
+    parser.add_argument("--review", help=LANG_CONFIG["en"]["review_help"])
+    parser.add_argument("--examples", help=LANG_CONFIG["en"]["examples_help"])
+    parser.add_argument("--work-patch", help=LANG_CONFIG["en"]["work_patch_help"])
+    parser.add_argument("--persona-patch", help=LANG_CONFIG["en"]["persona_patch_help"])
     parser.add_argument(
         "--base-dir",
         default="./colleagues",
-        help="同事 Skill 根目录（默认：./colleagues）",
+        help=LANG_CONFIG["en"]["base_dir_help"],
     )
 
     args = parser.parse_args()
     base_dir = Path(args.base_dir).expanduser()
+    is_reviewer_base_dir = "reviewers" in base_dir.parts
 
     if args.action == "list":
-        colleagues = list_colleagues(base_dir)
-        if not colleagues:
-            print("暂无已创建的同事 Skill")
+        skills = list_skills(base_dir)
+        if not skills:
+            empty_key = "reviewer_list_empty" if is_reviewer_base_dir else "list_empty"
+            print(LANG_CONFIG["en"][empty_key])
         else:
-            print(f"已创建 {len(colleagues)} 个同事 Skill：\n")
-            for c in colleagues:
-                updated = c["updated_at"][:10] if c["updated_at"] else "未知"
-                print(f"  [{c['slug']}]  {c['name']} — {c['identity']}")
-                print(f"    版本: {c['version']}  纠正次数: {c['corrections_count']}  更新: {updated}")
+            if all(skill["reviewer_type"] for skill in skills):
+                print(LANG_CONFIG["en"]["reviewer_list_header"].format(count=len(skills)))
+            else:
+                print(LANG_CONFIG["en"]["list_header"].format(count=len(skills)))
+            for skill in skills:
+                updated = (
+                    skill["updated_at"][:10]
+                    if skill["updated_at"]
+                    else LANG_CONFIG["en"]["unknown_date"]
+                )
+                print(
+                    LANG_CONFIG["en"]["list_item"].format(
+                        slug=skill["slug"],
+                        name=skill["name"],
+                        identity=skill["identity"],
+                    )
+                )
+                if skill["reviewer_type"]:
+                    print(
+                        LANG_CONFIG["en"]["reviewer_list_meta"].format(
+                            reviewer_type=skill["reviewer_type"],
+                            version=skill["version"],
+                            corrections_count=skill["corrections_count"],
+                            updated=updated,
+                        )
+                    )
+                else:
+                    print(
+                        LANG_CONFIG["en"]["list_meta"].format(
+                            version=skill["version"],
+                            corrections_count=skill["corrections_count"],
+                            updated=updated,
+                        )
+                    )
                 print()
 
     elif args.action == "create":
         if not args.slug and not args.name:
-            print("错误：create 操作需要 --slug 或 --name", file=sys.stderr)
+            print(LANG_CONFIG["en"]["create_missing_name"], file=sys.stderr)
             sys.exit(1)
 
         meta: dict = {}
@@ -345,35 +764,90 @@ def main() -> None:
         if args.name:
             meta["name"] = args.name
 
+        language = get_language(meta)
+        config = LANG_CONFIG[language]
         slug = args.slug or slugify(meta.get("name", "colleague"))
 
-        work_content = ""
-        if args.work:
-            work_content = Path(args.work).read_text(encoding="utf-8")
-
-        persona_content = ""
-        if args.persona:
-            persona_content = Path(args.persona).read_text(encoding="utf-8")
+        work_content = Path(args.work).read_text(encoding="utf-8") if args.work else ""
+        persona_content = Path(args.persona).read_text(encoding="utf-8") if args.persona else ""
 
         skill_dir = create_skill(base_dir, slug, meta, work_content, persona_content)
-        print(f"✅ Skill 已创建：{skill_dir}")
-        print(f"   触发词：/{slug}")
+        print(config["created_skill"].format(skill_dir=skill_dir))
+        print(config["trigger_phrase"].format(slug=slug))
+
+    elif args.action == "create-reviewer":
+        if not args.slug and not args.name:
+            print(LANG_CONFIG["en"]["create_missing_name"], file=sys.stderr)
+            sys.exit(1)
+        if not args.reviewer_type:
+            print(LANG_CONFIG["en"]["create_reviewer_missing_type"], file=sys.stderr)
+            sys.exit(1)
+        if not args.review:
+            print(LANG_CONFIG["en"]["create_reviewer_missing_review"], file=sys.stderr)
+            sys.exit(1)
+        if not args.examples:
+            print(LANG_CONFIG["en"]["create_reviewer_missing_examples"], file=sys.stderr)
+            sys.exit(1)
+
+        meta: dict = {}
+        if args.meta:
+            meta = json.loads(Path(args.meta).read_text(encoding="utf-8"))
+        if args.name:
+            meta["name"] = args.name
+
+        language = get_language(meta)
+        config = LANG_CONFIG[language]
+        slug = args.slug or slugify(meta.get("name", "reviewer"))
+        review_content = Path(args.review).read_text(encoding="utf-8")
+        examples_content = Path(args.examples).read_text(encoding="utf-8")
+
+        skill_dir = create_reviewer_skill(
+            base_dir=base_dir,
+            reviewer_type=args.reviewer_type,
+            slug=slug,
+            meta=meta,
+            review_content=review_content,
+            examples_content=examples_content,
+        )
+        trigger = get_reviewer_skill_name(args.reviewer_type, slug)
+        print(
+            config["created_reviewer"].format(
+                reviewer_label=get_reviewer_label(args.reviewer_type, language),
+                skill_dir=skill_dir,
+            )
+        )
+        print(config["reviewer_trigger_phrase"].format(trigger=trigger))
 
     elif args.action == "update":
         if not args.slug:
-            print("错误：update 操作需要 --slug", file=sys.stderr)
+            print(LANG_CONFIG["en"]["update_missing_slug"], file=sys.stderr)
             sys.exit(1)
 
         skill_dir = base_dir / args.slug
         if not skill_dir.exists():
-            print(f"错误：找不到 Skill 目录 {skill_dir}", file=sys.stderr)
+            print(
+                LANG_CONFIG["en"]["skill_dir_missing"].format(skill_dir=skill_dir),
+                file=sys.stderr,
+            )
             sys.exit(1)
 
-        work_patch = Path(args.work_patch).read_text(encoding="utf-8") if args.work_patch else None
-        persona_patch = Path(args.persona_patch).read_text(encoding="utf-8") if args.persona_patch else None
+        work_patch = (
+            Path(args.work_patch).read_text(encoding="utf-8")
+            if args.work_patch
+            else None
+        )
+        persona_patch = (
+            Path(args.persona_patch).read_text(encoding="utf-8")
+            if args.persona_patch
+            else None
+        )
+
+        meta = json.loads((skill_dir / "meta.json").read_text(encoding="utf-8"))
+        language = get_language(meta)
+        config = LANG_CONFIG[language]
 
         new_version = update_skill(skill_dir, work_patch, persona_patch)
-        print(f"✅ Skill 已更新到 {new_version}：{skill_dir}")
+        print(config["updated_skill"].format(version=new_version, skill_dir=skill_dir))
 
 
 if __name__ == "__main__":

--- a/tools/version_manager.py
+++ b/tools/version_manager.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """
-版本管理器
+Version manager for generated skills.
 
-负责 Skill 文件的版本存档和回滚。
+Handles version backups, listing archived versions, rollback, and cleanup.
 
-用法：
+Usage:
     python version_manager.py --action list --slug zhangsan --base-dir ~/.openclaw/...
     python version_manager.py --action backup --slug zhangsan --base-dir ~/.openclaw/...
     python version_manager.py --action rollback --slug zhangsan --version v2 --base-dir ~/.openclaw/...
@@ -12,18 +12,28 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 import shutil
-import argparse
 import sys
-from pathlib import Path
 from datetime import datetime, timezone
+from pathlib import Path
 
-MAX_VERSIONS = 10  # 最多保留的版本数
+MAX_VERSIONS = 10
+
+
+def managed_content_files(skill_dir: Path) -> tuple[str, ...]:
+    """Detect which content files belong to this generated skill."""
+    reviewer_files = ("SKILL.md", "review.md", "examples.md")
+    colleague_files = ("SKILL.md", "work.md", "persona.md")
+
+    if any((skill_dir / name).exists() for name in ("review.md", "examples.md")):
+        return reviewer_files
+    return colleague_files
 
 
 def list_versions(skill_dir: Path) -> list:
-    """列出所有历史版本"""
+    """List all archived versions for a skill."""
     versions_dir = skill_dir / "versions"
     if not versions_dir.exists():
         return []
@@ -33,55 +43,50 @@ def list_versions(skill_dir: Path) -> list:
         if not v_dir.is_dir():
             continue
 
-        # 从目录名解析版本号
         version_name = v_dir.name
-
-        # 获取存档时间（用目录修改时间近似）
         mtime = v_dir.stat().st_mtime
         archived_at = datetime.fromtimestamp(mtime, tz=timezone.utc).strftime("%Y-%m-%d %H:%M")
-
-        # 统计文件
         files = [f.name for f in v_dir.iterdir() if f.is_file()]
 
-        versions.append({
-            "version": version_name,
-            "archived_at": archived_at,
-            "files": files,
-            "path": str(v_dir),
-        })
+        versions.append(
+            {
+                "version": version_name,
+                "archived_at": archived_at,
+                "files": files,
+                "path": str(v_dir),
+            }
+        )
 
     return versions
 
 
 def rollback(skill_dir: Path, target_version: str) -> bool:
-    """回滚到指定版本"""
+    """Roll back the skill to a specific archived version."""
     version_dir = skill_dir / "versions" / target_version
 
     if not version_dir.exists():
-        print(f"错误：版本 {target_version} 不存在", file=sys.stderr)
+        print(f"error: version {target_version} does not exist", file=sys.stderr)
         return False
 
-    # 先存档当前版本
     meta_path = skill_dir / "meta.json"
+    current_version = "v?"
     if meta_path.exists():
         meta = json.loads(meta_path.read_text(encoding="utf-8"))
         current_version = meta.get("version", "v?")
         backup_dir = skill_dir / "versions" / f"{current_version}_before_rollback"
         backup_dir.mkdir(parents=True, exist_ok=True)
-        for fname in ("SKILL.md", "work.md", "persona.md"):
+        for fname in managed_content_files(skill_dir):
             src = skill_dir / fname
             if src.exists():
                 shutil.copy2(src, backup_dir / fname)
 
-    # 从目标版本恢复文件
     restored_files = []
-    for fname in ("SKILL.md", "work.md", "persona.md"):
+    for fname in managed_content_files(skill_dir):
         src = version_dir / fname
         if src.exists():
             shutil.copy2(src, skill_dir / fname)
             restored_files.append(fname)
 
-    # 更新 meta
     if meta_path.exists():
         meta = json.loads(meta_path.read_text(encoding="utf-8"))
         meta["version"] = target_version + "_restored"
@@ -89,15 +94,15 @@ def rollback(skill_dir: Path, target_version: str) -> bool:
         meta["rollback_from"] = current_version
         meta_path.write_text(json.dumps(meta, ensure_ascii=False, indent=2), encoding="utf-8")
 
-    print(f"已回滚到 {target_version}，恢复文件：{', '.join(restored_files)}")
+    print(f"rolled back to {target_version}; restored files: {', '.join(restored_files)}")
     return True
 
 
 def backup_current_version(skill_dir: Path) -> bool:
-    """将当前版本存档到 versions/ 目录"""
+    """Archive the current version into the `versions/` directory."""
     meta_path = skill_dir / "meta.json"
     if not meta_path.exists():
-        print(f"错误：找不到 meta.json，无法确定当前版本号", file=sys.stderr)
+        print("error: meta.json not found, cannot determine the current version", file=sys.stderr)
         return False
 
     meta = json.loads(meta_path.read_text(encoding="utf-8"))
@@ -107,27 +112,26 @@ def backup_current_version(skill_dir: Path) -> bool:
     version_dir.mkdir(parents=True, exist_ok=True)
 
     backed_up = []
-    for fname in ("SKILL.md", "work.md", "persona.md"):
+    for fname in managed_content_files(skill_dir):
         src = skill_dir / fname
         if src.exists():
             shutil.copy2(src, version_dir / fname)
             backed_up.append(fname)
 
     if backed_up:
-        print(f"已存档版本 {current_version}，文件：{', '.join(backed_up)}")
+        print(f"archived version {current_version}; files: {', '.join(backed_up)}")
     else:
-        print(f"警告：{current_version} 无可存档的文件")
+        print(f"warning: no files available to archive for {current_version}")
 
     return True
 
 
-def cleanup_old_versions(skill_dir: Path, max_versions: int = MAX_VERSIONS):
-    """清理超出限制的旧版本"""
+def cleanup_old_versions(skill_dir: Path, max_versions: int = MAX_VERSIONS) -> None:
+    """Delete old archived versions beyond the retention limit."""
     versions_dir = skill_dir / "versions"
     if not versions_dir.exists():
         return
 
-    # 按版本号排序，保留最新的 max_versions 个
     version_dirs = sorted(
         [d for d in versions_dir.iterdir() if d.is_dir()],
         key=lambda d: d.stat().st_mtime,
@@ -137,18 +141,18 @@ def cleanup_old_versions(skill_dir: Path, max_versions: int = MAX_VERSIONS):
 
     for old_dir in to_delete:
         shutil.rmtree(old_dir)
-        print(f"已清理旧版本：{old_dir.name}")
+        print(f"deleted old version: {old_dir.name}")
 
 
-def main():
-    parser = argparse.ArgumentParser(description="Skill 版本管理器")
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Skill version manager")
     parser.add_argument("--action", required=True, choices=["list", "backup", "rollback", "cleanup"])
-    parser.add_argument("--slug", required=True, help="同事 slug")
-    parser.add_argument("--version", help="目标版本号（rollback 时使用）")
+    parser.add_argument("--slug", required=True, help="skill slug")
+    parser.add_argument("--version", help="target version (used with rollback)")
     parser.add_argument(
         "--base-dir",
         default="~/.openclaw/workspace/skills/colleagues",
-        help="同事 Skill 根目录",
+        help="root directory for generated skills",
     )
 
     args = parser.parse_args()
@@ -156,30 +160,32 @@ def main():
     skill_dir = base_dir / args.slug
 
     if not skill_dir.exists():
-        print(f"错误：找不到 Skill 目录 {skill_dir}", file=sys.stderr)
+        print(f"error: skill directory not found: {skill_dir}", file=sys.stderr)
         sys.exit(1)
 
     if args.action == "list":
         versions = list_versions(skill_dir)
         if not versions:
-            print(f"{args.slug} 暂无历史版本")
+            print(f"{args.slug} has no archived versions yet")
         else:
-            print(f"{args.slug} 的历史版本：\n")
-            for v in versions:
-                print(f"  {v['version']}  存档时间: {v['archived_at']}  文件: {', '.join(v['files'])}")
+            print(f"Archived versions for {args.slug}:\n")
+            for version in versions:
+                print(
+                    f"  {version['version']}  archived: {version['archived_at']}  files: {', '.join(version['files'])}"
+                )
 
     elif args.action == "backup":
         backup_current_version(skill_dir)
 
     elif args.action == "rollback":
         if not args.version:
-            print("错误：rollback 操作需要 --version", file=sys.stderr)
+            print("error: rollback requires --version", file=sys.stderr)
             sys.exit(1)
         rollback(skill_dir, args.version)
 
     elif args.action == "cleanup":
         cleanup_old_versions(skill_dir)
-        print("清理完成")
+        print("cleanup complete")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add separate review-only generator flows for PR and design reviewers, with dedicated prompts, command routing, version support, and README documentation
- carry the local English translation work for the main prompt/tooling surface into the branch so the shared writer/version utilities and core docs are usable in English
- add automated coverage for reviewer writer creation, reviewer rollback, prompt inventory, and documented command surface

## Test Plan
- [x] `python3 -m unittest discover -s tests -p 'test_*.py' -v`
- [x] `python3 -m py_compile tools/*.py`
- [x] `git diff --check`
- [x] smoke-tested `python3 tools/skill_writer.py --action create-reviewer --reviewer-type pr ...`
- [x] smoke-tested `python3 tools/skill_writer.py --action create-reviewer --reviewer-type design ...`
