### PR TITLE
feat: add Confluence auto-collector as new data source

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -65,6 +65,7 @@ pip3 install openpyxl        # Excel .xlsx 转 CSV
 | 钉钉用户 | `dingtalk_auto_collector.py` |
 | 钉钉消息采集失败 | 手动截图 → 上传图片 |
 | Slack 用户 | `slack_auto_collector.py` |
+| Confluence 用户 | `confluence_auto_collector.py` |
 
 **飞书自动采集初始化**：
 ```bash
@@ -99,6 +100,14 @@ python3 tools/slack_auto_collector.py --setup
 ```
 
 > Slack 详细配置见下方「[Slack 自动采集配置](#slack-自动采集配置)」章节
+
+**Confluence 自动采集初始化**：
+```bash
+python3 tools/confluence_auto_collector.py --setup
+# 按提示选择 Cloud 或 Server/DC，输入 URL 和认证信息
+```
+
+> Confluence 详细配置见下方「[Confluence 自动采集配置](#confluence-自动采集配置)」章节
 
 ---
 
@@ -211,6 +220,102 @@ knowledge/张三/
 | 消息只有 90 天 | 免费版限制 | 升级 Workspace 或手动补充截图 |
 | 速率限制（429）| 请求太频繁 | 脚本会自动等待重试，无需手动处理 |
 
+---
+
+## Confluence 自动采集配置
+
+### 前置条件
+
+- Python 3.9+
+- `pip3 install requests`（通常已安装）
+- Confluence Cloud 或 Server/Data Center 的访问权限
+
+---
+
+### Confluence Cloud 配置
+
+#### 步骤 1：创建 API Token
+
+1. 前往 [https://id.atlassian.com/manage-profile/security/api-tokens](https://id.atlassian.com/manage-profile/security/api-tokens)
+2. 点击 **Create API token**
+3. 填写标签名（如 `colleague-skill`）→ **Create**
+4. 复制生成的 Token（只显示一次）
+
+#### 步骤 2：运行配置向导
+
+```bash
+python3 tools/confluence_auto_collector.py --setup
+```
+
+选择 `[1] Confluence Cloud`，按提示输入：
+- Confluence URL（如 `https://yourcompany.atlassian.net`）
+- Atlassian 账号邮箱
+- API Token
+
+配置成功后会自动验证连接并保存到 `~/.colleague-skill/confluence_config.json`。
+
+---
+
+### Confluence Server / Data Center 配置
+
+#### 方式 A：Personal Access Token（推荐）
+
+1. 登录 Confluence → 右上角头像 → **Settings** → **Personal Access Tokens**
+2. 点击 **Create token** → 填写名称 → **Create**
+3. 复制 Token
+
+#### 方式 B：用户名 + 密码
+
+直接使用 Confluence 登录的用户名和密码。
+
+#### 运行配置向导
+
+```bash
+python3 tools/confluence_auto_collector.py --setup
+```
+
+选择 `[2] Confluence Server / Data Center`，按提示输入 URL 和认证信息。
+
+---
+
+### 采集同事数据
+
+```bash
+# 基本用法
+python3 tools/confluence_auto_collector.py --name "John Doe"
+
+# 指定输出目录
+python3 tools/confluence_auto_collector.py --name "john.doe" --output-dir ./knowledge/john
+
+# 按 Space 过滤
+python3 tools/confluence_auto_collector.py --name "John" --space-key DEV --doc-limit 30
+
+# 调整采集量
+python3 tools/confluence_auto_collector.py --name "John" --doc-limit 100 --comment-limit 500
+```
+
+输出文件：
+```
+knowledge/john/
+├── docs.txt                # 页面内容（按长度分类）
+├── messages.txt            # 评论内容（按长度分类）
+└── collection_summary.json # 采集摘要
+```
+
+---
+
+### 常见报错与解决
+
+| 报错 | 原因 | 解决 |
+|------|------|------|
+| `Auth failed: Invalid credentials` | Token/密码无效 | 重新运行 `--setup` 配置 |
+| `Permission denied` | 账号无权访问该 Space | 联系 Confluence 管理员授权 |
+| `User not found` | 姓名不匹配 | 使用 Confluence 中显示的完整姓名或用户名 |
+| `Connection failed` | URL 错误或网络问题 | 检查 Confluence URL 是否正确 |
+| 速率限制（429）| 请求太频繁 | 脚本会自动等待重试，无需手动处理 |
+
+---
+
 ## 快速验证
 
 ```bash
@@ -221,6 +326,9 @@ python3 tools/feishu_parser.py --help
 
 # 测试 Slack 采集器
 python3 tools/slack_auto_collector.py --help
+
+# 测试 Confluence 采集器
+python3 tools/confluence_auto_collector.py --help
 
 # 测试邮件解析器
 python3 tools/email_parser.py --help

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Your predecessor handed over, trying to condense three years into three pages?<b
 
 <br>
 
-Provide source materials (Feishu messages, DingTalk docs, Slack messages, emails, screenshots)<br>
+Provide source materials (Feishu messages, DingTalk docs, Slack messages, Confluence pages, emails, screenshots)<br>
 plus your subjective description of the person<br>
 and get an **AI Skill that actually works like them**
 
@@ -62,6 +62,7 @@ Created by [@titanwings](https://github.com/titanwings) | Powered by Shanghai AI
 | Feishu (auto) | ✅ API | ✅ | ✅ | Just enter a name, fully automatic |
 | DingTalk (auto) | ⚠️ Browser | ✅ | ✅ | DingTalk API doesn't support message history |
 | Slack (auto) | ✅ API | — | — | Requires admin to install Bot; free plan limited to 90 days |
+| Confluence (auto) | ✅ Comments | ✅ Pages/Wiki | — | Supports Cloud + Server/DC; requires API Token or PAT |
 | WeChat chat history | ✅ SQLite | — | — | Currently unstable, recommend using open-source tools below |
 | PDF | — | ✅ | — | Manual upload |
 | Images / Screenshots | ✅ | — | — | Manual upload |
@@ -111,7 +112,7 @@ git clone https://github.com/titanwings/colleague-skill ~/.openclaw/workspace/sk
 pip3 install -r requirements.txt
 ```
 
-> Feishu/DingTalk/Slack auto-collection requires App credentials. See [INSTALL.md](INSTALL.md) for details.
+> Feishu/DingTalk/Slack/Confluence auto-collection requires App credentials. See [INSTALL.md](INSTALL.md) for details.
 
 ---
 
@@ -216,6 +217,7 @@ create-colleague/
 │   ├── feishu_mcp_client.py      # Feishu MCP method
 │   ├── dingtalk_auto_collector.py # DingTalk auto-collector
 │   ├── slack_auto_collector.py   # Slack auto-collector
+│   ├── confluence_auto_collector.py # Confluence auto-collector
 │   ├── email_parser.py           # Email parser
 │   ├── skill_writer.py           # Skill file management
 │   └── version_manager.py        # Version archive & rollback

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-colleague
-description: "Distill a colleague into an AI Skill. Auto-collect Feishu/DingTalk data, generate Work Skill + Persona, with continuous evolution. | 把同事蒸馏成 AI Skill，自动采集飞书/钉钉数据，生成 Work + Persona，支持持续进化。"
+description: "Distill a colleague into an AI Skill. Auto-collect Feishu/DingTalk/Confluence data, generate Work Skill + Persona, with continuous evolution. | 把同事蒸馏成 AI Skill，自动采集飞书/钉钉/Confluence数据，生成 Work + Persona，支持持续进化。"
 argument-hint: "[colleague-name-or-slug]"
 version: "1.0.0"
 user-invocable: true
@@ -45,6 +45,7 @@ allowed-tools: Read, Write, Edit, Bash
 | 飞书文档（浏览器登录态） | `Bash` → `python3 ${CLAUDE_SKILL_DIR}/tools/feishu_browser.py` |
 | 飞书文档（MCP App Token） | `Bash` → `python3 ${CLAUDE_SKILL_DIR}/tools/feishu_mcp_client.py` |
 | 钉钉全自动采集 | `Bash` → `python3 ${CLAUDE_SKILL_DIR}/tools/dingtalk_auto_collector.py` |
+| Confluence 自动采集 | `Bash` → `python3 ${CLAUDE_SKILL_DIR}/tools/confluence_auto_collector.py` |
 | 解析邮件 .eml/.mbox | `Bash` → `python3 ${CLAUDE_SKILL_DIR}/tools/email_parser.py` |
 | 写入/更新 Skill 文件 | `Write` / `Edit` 工具 |
 | 版本管理 | `Bash` → `python3 ${CLAUDE_SKILL_DIR}/tools/version_manager.py` |
@@ -82,6 +83,10 @@ allowed-tools: Read, Write, Edit, Bash
   [B] 钉钉自动采集
       输入姓名，自动拉取文档 + 多维表格
       消息记录通过浏览器采集（钉钉 API 不支持历史消息）
+
+  [B2] Confluence 自动采集
+       输入姓名，自动拉取该用户创建/编辑的页面 + 评论
+       支持 Cloud 和 Server/Data Center
 
   [C] 飞书链接
       直接给文档/Wiki 链接（浏览器登录态 或 MCP）
@@ -240,6 +245,46 @@ python3 ${CLAUDE_SKILL_DIR}/tools/dingtalk_auto_collector.py \
 - `knowledge/{slug}/messages.txt`
 
 如消息采集失败，提示用户截图聊天记录后上传。
+
+---
+
+#### 方式 B2：Confluence 自动采集
+
+首次使用需配置：
+```bash
+python3 ${CLAUDE_SKILL_DIR}/tools/confluence_auto_collector.py --setup
+```
+
+然后输入姓名，一键采集：
+```bash
+python3 ${CLAUDE_SKILL_DIR}/tools/confluence_auto_collector.py \
+  --name "{name}" \
+  --output-dir ./knowledge/{slug} \
+  --doc-limit 50 \
+  --comment-limit 200
+```
+
+可选：按 Space 过滤：
+```bash
+python3 ${CLAUDE_SKILL_DIR}/tools/confluence_auto_collector.py \
+  --name "{name}" \
+  --space-key DEV \
+  --output-dir ./knowledge/{slug}
+```
+
+采集内容：
+- 该用户创建/编辑的 Confluence 页面（技术文档、设计文档、Wiki 等）
+- 该用户发表的评论/回复（Code Review 意见、讨论等）
+
+采集完成后 `Read` 读取：
+- `knowledge/{slug}/docs.txt` → 页面内容
+- `knowledge/{slug}/messages.txt` → 评论内容
+- `knowledge/{slug}/collection_summary.json` → 采集摘要
+
+如采集失败，常见问题：
+- 认证失败：API Token 过期或无效，重新运行 --setup
+- 权限不足：确认账号有对应 Space 的读取权限
+- 用户未找到：尝试使用 Confluence 中显示的完整姓名或用户名
 
 ---
 
@@ -545,6 +590,7 @@ This Skill runs in the Claude Code environment with the following tools:
 | Feishu docs (browser session) | `Bash` → `python3 ${CLAUDE_SKILL_DIR}/tools/feishu_browser.py` |
 | Feishu docs (MCP App Token) | `Bash` → `python3 ${CLAUDE_SKILL_DIR}/tools/feishu_mcp_client.py` |
 | DingTalk auto-collect | `Bash` → `python3 ${CLAUDE_SKILL_DIR}/tools/dingtalk_auto_collector.py` |
+| Confluence auto-collect | `Bash` → `python3 ${CLAUDE_SKILL_DIR}/tools/confluence_auto_collector.py` |
 | Parse email .eml/.mbox | `Bash` → `python3 ${CLAUDE_SKILL_DIR}/tools/email_parser.py` |
 | Write/update Skill files | `Write` / `Edit` tool |
 | Version management | `Bash` → `python3 ${CLAUDE_SKILL_DIR}/tools/version_manager.py` |
@@ -582,6 +628,10 @@ How would you like to provide source materials?
   [B] DingTalk Auto-Collect
       Enter name, auto-pull docs + spreadsheets
       Messages collected via browser (DingTalk API doesn't support message history)
+
+  [B2] Confluence Auto-Collect
+       Enter name, auto-pull pages created/edited by the user + comments
+       Supports Cloud and Server/Data Center
 
   [C] Feishu Link
       Provide doc/Wiki link (browser session or MCP)
@@ -740,6 +790,46 @@ After collection, `Read`:
 - `knowledge/{slug}/messages.txt`
 
 If message collection fails, prompt user to upload chat screenshots.
+
+---
+
+#### Option B2: Confluence Auto-Collect
+
+First-time setup:
+```bash
+python3 ${CLAUDE_SKILL_DIR}/tools/confluence_auto_collector.py --setup
+```
+
+Then enter the name:
+```bash
+python3 ${CLAUDE_SKILL_DIR}/tools/confluence_auto_collector.py \
+  --name "{name}" \
+  --output-dir ./knowledge/{slug} \
+  --doc-limit 50 \
+  --comment-limit 200
+```
+
+Optional: filter by Space:
+```bash
+python3 ${CLAUDE_SKILL_DIR}/tools/confluence_auto_collector.py \
+  --name "{name}" \
+  --space-key DEV \
+  --output-dir ./knowledge/{slug}
+```
+
+Collected content:
+- Confluence pages created/edited by the user (technical docs, design docs, wikis, etc.)
+- Comments/replies by the user (code review feedback, discussions, etc.)
+
+After collection, `Read`:
+- `knowledge/{slug}/docs.txt` → page content
+- `knowledge/{slug}/messages.txt` → comment content
+- `knowledge/{slug}/collection_summary.json` → collection summary
+
+If collection fails, common issues:
+- Auth failure: API Token expired or invalid, re-run --setup
+- Permission denied: confirm the account has read access to the target Space
+- User not found: try the exact display name or username shown in Confluence
 
 ---
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# Required
+# Required (also used by Confluence auto collector)
 requests>=2.28.0
 
 # Optional: Chinese name → slug conversion

--- a/tools/confluence_auto_collector.py
+++ b/tools/confluence_auto_collector.py
@@ -1,0 +1,886 @@
+#!/usr/bin/env python3
+"""
+Confluence auto-collector
+
+Input a colleague's Confluence username/display name, automatically:
+  1. Search Confluence user
+  2. Pull pages created/edited by the user
+  3. Pull comments/replies by the user
+  4. Output in unified format for create-colleague analysis
+
+Setup:
+  python3 confluence_auto_collector.py --setup
+
+Usage:
+  python3 confluence_auto_collector.py --name "John Doe" --output-dir ./knowledge/john
+  python3 confluence_auto_collector.py --name "john.doe" --doc-limit 30 --space-key DEV
+
+Requirements:
+  Confluence Cloud: API Token (https://id.atlassian.com/manage-profile/security/api-tokens)
+  Confluence Server/DC: username + password, or Personal Access Token
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+import argparse
+import re
+from pathlib import Path
+from datetime import datetime, timezone
+from typing import Optional
+from urllib.parse import quote
+from base64 import b64encode
+
+try:
+    import requests
+except ImportError:
+    print(
+        "Error: please install requests first: pip3 install requests",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+# --- Constants ----------------------------------------------------------------
+
+CONFIG_PATH = Path.home() / ".colleague-skill" / "confluence_config.json"
+
+MAX_RETRIES = 5
+RETRY_BASE_WAIT = 1.0
+RETRY_MAX_WAIT = 60.0
+
+DEFAULT_DOC_LIMIT = 50
+DEFAULT_COMMENT_LIMIT = 200
+
+
+# --- Error types --------------------------------------------------------------
+
+
+class CollectorError(Exception):
+    pass
+
+
+class AuthError(CollectorError):
+    pass
+
+
+class PermissionError_(CollectorError):
+    pass
+
+
+# --- Config management --------------------------------------------------------
+
+
+def load_config() -> dict:
+    if not CONFIG_PATH.exists():
+        print(
+            "Config not found. Run: python3 confluence_auto_collector.py --setup",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    try:
+        return json.loads(CONFIG_PATH.read_text())
+    except json.JSONDecodeError:
+        print(f"Config file corrupted, re-run --setup: {CONFIG_PATH}", file=sys.stderr)
+        sys.exit(1)
+
+
+def save_config(config: dict) -> None:
+    CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    CONFIG_PATH.write_text(json.dumps(config, indent=2, ensure_ascii=False))
+
+
+def setup_config() -> None:
+    print("=== Confluence Auto-Collector Setup ===\n")
+    print("Supports Confluence Cloud and Server/Data Center\n")
+
+    print("Select Confluence type:")
+    print("  [1] Confluence Cloud (xxx.atlassian.net)")
+    print("  [2] Confluence Server / Data Center")
+    choice = input("\nChoose [1/2] (default 1): ").strip() or "1"
+
+    if choice == "1":
+        print("\n--- Confluence Cloud ---")
+        print(
+            "Step 1: Go to https://id.atlassian.com/manage-profile/security/api-tokens"
+        )
+        print("        Create an API Token\n")
+
+        base_url = input(
+            "Confluence URL (e.g. https://yourcompany.atlassian.net): "
+        ).strip()
+        if not base_url.startswith("http"):
+            base_url = "https://" + base_url
+        base_url = base_url.rstrip("/")
+
+        email = input("Atlassian account email: ").strip()
+        api_token = input("API Token: ").strip()
+
+        config = {
+            "type": "cloud",
+            "base_url": base_url,
+            "email": email,
+            "api_token": api_token,
+        }
+    else:
+        print("\n--- Confluence Server/DC ---")
+        base_url = input(
+            "Confluence URL (e.g. https://confluence.yourcompany.com): "
+        ).strip()
+        if not base_url.startswith("http"):
+            base_url = "https://" + base_url
+        base_url = base_url.rstrip("/")
+
+        print("\nAuth method:")
+        print("  [1] Username + Password")
+        print("  [2] Personal Access Token (PAT)")
+        auth_choice = input("Choose [1/2] (default 1): ").strip() or "1"
+
+        if auth_choice == "2":
+            token = input("Personal Access Token: ").strip()
+            config = {
+                "type": "server",
+                "base_url": base_url,
+                "auth_method": "pat",
+                "token": token,
+            }
+        else:
+            username = input("Username: ").strip()
+            password = input("Password: ").strip()
+            config = {
+                "type": "server",
+                "base_url": base_url,
+                "auth_method": "basic",
+                "username": username,
+                "password": password,
+            }
+
+    # Verify connection
+    print("\nVerifying connection ...", end=" ", flush=True)
+    try:
+        client = ConfClient(config)
+        info = client.get("/rest/api/space", params={"limit": 1})
+        if info is not None:
+            print("OK")
+            spaces = info.get("results", [])
+            if spaces:
+                print(
+                    f"  Accessible space: {spaces[0].get('key')} - {spaces[0].get('name')}"
+                )
+        else:
+            print("Connection failed", file=sys.stderr)
+            sys.exit(1)
+    except AuthError as e:
+        print(f"Auth failed: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        print(f"Connection failed: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    save_config(config)
+    print(f"\nConfig saved to {CONFIG_PATH}")
+
+
+# --- Confluence HTTP Client ---------------------------------------------------
+
+
+class ConfClient:
+    """Confluence REST API client with rate-limit retry."""
+
+    def __init__(self, config: dict) -> None:
+        self._base_url = config["base_url"]
+        self._session = requests.Session()
+        self._session.headers["Accept"] = "application/json"
+
+        conf_type = config.get("type", "cloud")
+        if conf_type == "cloud":
+            email = config["email"]
+            token = config["api_token"]
+            cred = b64encode(f"{email}:{token}".encode()).decode()
+            self._session.headers["Authorization"] = f"Basic {cred}"
+        else:
+            auth_method = config.get("auth_method", "basic")
+            if auth_method == "pat":
+                self._session.headers["Authorization"] = f"Bearer {config['token']}"
+            else:
+                cred = b64encode(
+                    f"{config['username']}:{config['password']}".encode()
+                ).decode()
+                self._session.headers["Authorization"] = f"Basic {cred}"
+
+    def get(self, path: str, params: dict = None) -> Optional[dict]:
+        return self._request("GET", path, params=params)
+
+    def _request(self, method: str, path: str, **kwargs) -> Optional[dict]:
+        url = self._base_url + path
+
+        for attempt in range(1, MAX_RETRIES + 1):
+            try:
+                resp = self._session.request(method, url, timeout=30, **kwargs)
+            except requests.RequestException as e:
+                print(f"  [Network error] {e}", file=sys.stderr)
+                if attempt < MAX_RETRIES:
+                    time.sleep(RETRY_BASE_WAIT * attempt)
+                    continue
+                return None
+
+            if resp.status_code == 200:
+                return resp.json()
+
+            if resp.status_code == 401:
+                raise AuthError("Invalid credentials. Re-run --setup.")
+
+            if resp.status_code == 403:
+                raise PermissionError_(f"Permission denied: {path}")
+
+            if resp.status_code == 429:
+                wait = float(resp.headers.get("Retry-After", RETRY_BASE_WAIT * attempt))
+                wait = min(wait, RETRY_MAX_WAIT)
+                print(
+                    f"  [Rate limit] waiting {wait:.0f}s (attempt {attempt}/{MAX_RETRIES})...",
+                    file=sys.stderr,
+                )
+                time.sleep(wait)
+                continue
+
+            if resp.status_code == 404:
+                return None
+
+            print(
+                f"  [API warning] {method} {path} returned {resp.status_code}",
+                file=sys.stderr,
+            )
+            return None
+
+        print(
+            f"  [Error] {method} {path} failed after {MAX_RETRIES} retries",
+            file=sys.stderr,
+        )
+        return None
+
+    def paginate(self, path: str, params: dict = None, limit: int = 50) -> list:
+        """Auto-paginate through Confluence REST API results."""
+        results = []
+        start = 0
+        page_size = min(limit, 50)
+
+        while len(results) < limit:
+            p = dict(params or {})
+            p["start"] = start
+            p["limit"] = page_size
+
+            data = self.get(path, params=p)
+            if not data:
+                break
+
+            page_results = data.get("results", [])
+            if not page_results:
+                break
+
+            results.extend(page_results)
+            start += len(page_results)
+
+            size_info = data.get("size", 0)
+            if size_info < page_size:
+                break
+
+        return results[:limit]
+
+
+# --- User search --------------------------------------------------------------
+
+
+def find_user(name: str, client: ConfClient, config: dict) -> Optional[dict]:
+    """Search for a Confluence user by display name or username.
+
+    For Cloud: uses /rest/api/search/user to get accountId (required for CQL).
+    For Server/DC: uses /rest/api/search with user.fullname CQL.
+    """
+    print(f"  Searching user: {name} ...", file=sys.stderr)
+
+    conf_type = config.get("type", "cloud")
+
+    # --- Strategy 1: User search endpoint (Cloud) ---
+    if conf_type == "cloud":
+        data = client.get(
+            "/rest/api/search/user",
+            params={"cql": f'user.fullname ~ "{name}"', "limit": 10},
+        )
+        if data and data.get("results"):
+            candidates = data["results"]
+            if len(candidates) == 1:
+                u = candidates[0].get("user", {})
+                _print_found_user(u)
+                return _make_user_dict(u)
+
+            # Multiple matches: try exact match first
+            for c in candidates:
+                u = c.get("user", {})
+                dn = u.get("displayName", "")
+                # Exact match on name portion (before /)
+                dn_name = dn.split("/")[0].strip()
+                if dn_name == name or dn == name:
+                    _print_found_user(u)
+                    return _make_user_dict(u)
+
+            # No exact match: show candidates
+            print(f"\n  Found {len(candidates)} matches:", file=sys.stderr)
+            for i, c in enumerate(candidates[:10]):
+                u = c.get("user", {})
+                dn = u.get("displayName", "")
+                email = u.get("email", "")
+                print(f"    [{i + 1}] {dn}  ({email})", file=sys.stderr)
+
+            choice = input("\n  Choose number (default 1): ").strip() or "1"
+            try:
+                idx = int(choice) - 1
+                u = candidates[idx].get("user", {})
+            except (ValueError, IndexError):
+                u = candidates[0].get("user", {})
+
+            _print_found_user(u)
+            return _make_user_dict(u)
+
+        # Also try by email
+        data2 = client.get(
+            "/rest/api/search/user",
+            params={"cql": f'user.email = "{name}"', "limit": 1},
+        )
+        if data2 and data2.get("results"):
+            u = data2["results"][0].get("u", {})
+            _print_found_user(u)
+            return _make_user_dict(u)
+
+    # --- Strategy 2: Server/DC user search ---
+    else:
+        data = client.get(
+            "/rest/api/search",
+            params={
+                "cql": f'user.fullname ~ "{name}"',
+                "limit": 10,
+            },
+        )
+        if data and data.get("results"):
+            for r in data["results"]:
+                u = r.get("user", {})
+                if u:
+                    _print_found_user(u)
+                    return _make_user_dict(u)
+
+    # --- Strategy 3: Find user via content they authored ---
+    print(f"  Trying content-based user search...", file=sys.stderr)
+    content_data = client.get(
+        "/rest/api/search",
+        params={
+            "cql": f'creator = "{name}" AND type = page ORDER BY lastModified DESC',
+            "limit": 1,
+            "expand": "content.version",
+        },
+    )
+
+    if content_data and content_data.get("results"):
+        first = content_data["results"][0]
+        content = first.get("content", first)
+        version = content.get("version", {})
+        by = version.get("by", {})
+        if by:
+            _print_found_user(by)
+            return _make_user_dict(by)
+
+    print(f"  User not found: {name}", file=sys.stderr)
+    print(
+        "  Tip: try the exact display name or username shown in Confluence",
+        file=sys.stderr,
+    )
+    return None
+
+
+def _make_user_dict(user_data: dict) -> dict:
+    """Normalize user data into a standard dict."""
+    account_id = user_data.get("accountId", "")
+    return {
+        "username": user_data.get("username") or account_id,
+        "displayName": user_data.get("displayName", ""),
+        "accountId": account_id,
+        "userKey": user_data.get("userKey", ""),
+    }
+
+
+def _print_found_user(user_data: dict) -> None:
+    dn = user_data.get("displayName", "")
+    aid = user_data.get("accountId", "")
+    email = user_data.get("email", "")
+    print(f"  Found user: {dn} ({email or aid})", file=sys.stderr)
+
+
+# --- HTML to text conversion --------------------------------------------------
+
+
+def html_to_text(html: str) -> str:
+    """Simple HTML to plain text conversion."""
+    if not html:
+        return ""
+    # Remove script/style
+    text = re.sub(
+        r"<(script|style)[^>]*>.*?</\1>", "", html, flags=re.DOTALL | re.IGNORECASE
+    )
+    # Convert common tags
+    text = re.sub(r"<br\s*/?>", "\n", text, flags=re.IGNORECASE)
+    text = re.sub(r"</(p|div|h[1-6]|li|tr)>", "\n", text, flags=re.IGNORECASE)
+    text = re.sub(r"<(h[1-6])[^>]*>", "\n## ", text, flags=re.IGNORECASE)
+    text = re.sub(r"<li[^>]*>", "- ", text, flags=re.IGNORECASE)
+    # Remove remaining tags
+    text = re.sub(r"<[^>]+>", "", text)
+    # Decode entities
+    text = text.replace("&amp;", "&").replace("&lt;", "<").replace("&gt;", ">")
+    text = text.replace("&quot;", '"').replace("&nbsp;", " ").replace("&#39;", "'")
+    # Clean up whitespace
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+# --- Content collection -------------------------------------------------------
+
+
+def collect_pages(
+    user: dict,
+    client: ConfClient,
+    doc_limit: int,
+    space_key: Optional[str] = None,
+) -> list:
+    """Collect pages created or last-modified by the target user."""
+    name = user["displayName"]
+    # Cloud uses accountId for CQL creator, Server uses username
+    creator_id = user.get("accountId") or user.get("username", name)
+
+    print(f"  Fetching pages by {name} ...", file=sys.stderr)
+
+    # Build CQL query
+    cql_parts = [f'creator = "{creator_id}" AND type = page']
+    if space_key:
+        cql_parts.append(f'space = "{space_key}"')
+    cql = " AND ".join(cql_parts) + " ORDER BY lastModified DESC"
+
+    pages = []
+    start = 0
+    page_size = 25
+
+    while len(pages) < doc_limit:
+        data = client.get(
+            "/rest/api/search",
+            params={
+                "cql": cql,
+                "limit": page_size,
+                "start": start,
+                "expand": "content.body.storage,content.version,content.space",
+            },
+        )
+
+        if not data:
+            break
+
+        results = data.get("results", [])
+        if not results:
+            break
+
+        for r in results:
+            content = r.get("content", r)
+            title = content.get("title", r.get("title", "Untitled"))
+            space_info = content.get("space", {})
+            space_name = space_info.get("name", space_info.get("key", ""))
+
+            body_storage = content.get("body", {}).get("storage", {}).get("value", "")
+            body_text = html_to_text(body_storage)
+
+            version = content.get("version", {})
+            modified_by = version.get("by", {}).get("displayName", "")
+            modified_when = version.get("when", "")
+
+            if body_text and len(body_text) > 20:
+                pages.append(
+                    {
+                        "title": title,
+                        "space": space_name,
+                        "content": body_text,
+                        "modified_by": modified_by,
+                        "modified_when": modified_when[:10] if modified_when else "",
+                        "url": content.get("_links", {}).get("webui", ""),
+                    }
+                )
+
+        start += len(results)
+        total_size = data.get("totalSize", data.get("size", 0))
+        if start >= total_size or len(results) < page_size:
+            break
+
+    # Also fetch pages where user was last modifier (not just creator)
+    if len(pages) < doc_limit:
+        cql2_parts = [
+            f'contributor = "{creator_id}" AND type = page AND creator != "{creator_id}"'
+        ]
+        if space_key:
+            cql2_parts.append(f'space = "{space_key}"')
+        cql2 = " AND ".join(cql2_parts) + " ORDER BY lastModified DESC"
+
+        remaining = doc_limit - len(pages)
+        data2 = client.get(
+            "/rest/api/search",
+            params={
+                "cql": cql2,
+                "limit": min(remaining, 25),
+                "expand": "content.body.storage,content.version,content.space",
+            },
+        )
+
+        if data2:
+            for r in data2.get("results", []):
+                content = r.get("content", r)
+                title = content.get("title", r.get("title", "Untitled"))
+                space_info = content.get("space", {})
+                space_name = space_info.get("name", space_info.get("key", ""))
+
+                body_storage = (
+                    content.get("body", {}).get("storage", {}).get("value", "")
+                )
+                body_text = html_to_text(body_storage)
+
+                version = content.get("version", {})
+                modified_when = version.get("when", "")
+
+                if body_text and len(body_text) > 20:
+                    pages.append(
+                        {
+                            "title": title,
+                            "space": space_name,
+                            "content": body_text,
+                            "modified_by": name,
+                            "modified_when": modified_when[:10]
+                            if modified_when
+                            else "",
+                            "url": content.get("_links", {}).get("webui", ""),
+                        }
+                    )
+
+    print(f"  Collected {len(pages)} pages", file=sys.stderr)
+    return pages[:doc_limit]
+
+
+def collect_comments(
+    user: dict,
+    client: ConfClient,
+    comment_limit: int,
+    space_key: Optional[str] = None,
+) -> list:
+    """Collect comments made by the target user."""
+    name = user["displayName"]
+    creator_id = user.get("accountId") or user.get("username", name)
+
+    print(f"  Fetching comments by {name} ...", file=sys.stderr)
+
+    cql_parts = [f'creator = "{creator_id}" AND type = comment']
+    if space_key:
+        cql_parts.append(f'space = "{space_key}"')
+    cql = " AND ".join(cql_parts) + " ORDER BY created DESC"
+
+    comments = []
+    start = 0
+    page_size = 25
+
+    while len(comments) < comment_limit:
+        data = client.get(
+            "/rest/api/search",
+            params={
+                "cql": cql,
+                "limit": page_size,
+                "start": start,
+                "expand": "content.body.storage,content.container",
+            },
+        )
+
+        if not data:
+            break
+
+        results = data.get("results", [])
+        if not results:
+            break
+
+        for r in results:
+            content = r.get("content", r)
+            body_storage = content.get("body", {}).get("storage", {}).get("value", "")
+            body_text = html_to_text(body_storage)
+
+            if not body_text or len(body_text) < 5:
+                continue
+
+            container = content.get("container", {})
+            page_title = container.get("title", r.get("title", "Unknown page"))
+
+            created = content.get("version", {}).get("when", "")
+
+            comments.append(
+                {
+                    "page_title": page_title,
+                    "content": body_text,
+                    "created": created[:10] if created else "",
+                }
+            )
+
+        start += len(results)
+        total_size = data.get("totalSize", data.get("size", 0))
+        if start >= total_size or len(results) < page_size:
+            break
+
+    print(f"  Collected {len(comments)} comments", file=sys.stderr)
+    return comments[:comment_limit]
+
+
+# --- Format output ------------------------------------------------------------
+
+
+def format_docs(pages: list, user_name: str) -> str:
+    """Format collected pages into unified text output."""
+    lines = [
+        "# Confluence Pages (Auto-collected)",
+        f"Target: {user_name}",
+        f"Total: {len(pages)} pages",
+        "",
+        "---",
+        "",
+    ]
+
+    # Separate long docs from short ones
+    long_pages = [p for p in pages if len(p["content"]) > 200]
+    short_pages = [p for p in pages if len(p["content"]) <= 200]
+
+    if long_pages:
+        lines.append(
+            "## Detailed Documents (high weight: technical docs / design / specs)"
+        )
+        lines.append("")
+        for p in long_pages:
+            lines.append(f"### {p['title']}")
+            if p["space"]:
+                lines.append(f"Space: {p['space']}  |  Modified: {p['modified_when']}")
+            lines.append("")
+            lines.append(p["content"])
+            lines.append("")
+            lines.append("---")
+            lines.append("")
+
+    if short_pages:
+        lines.append("## Short Pages (reference)")
+        lines.append("")
+        for p in short_pages:
+            lines.append(f"### {p['title']}")
+            lines.append(p["content"])
+            lines.append("")
+
+    return "\n".join(lines)
+
+
+def format_comments(comments: list, user_name: str) -> str:
+    """Format collected comments into unified text output."""
+    lines = [
+        "# Confluence Comments (Auto-collected)",
+        f"Target: {user_name}",
+        f"Total: {len(comments)} comments",
+        "",
+        "---",
+        "",
+    ]
+
+    # Separate long comments (opinions/reviews) from short ones
+    long_comments = [c for c in comments if len(c["content"]) > 50]
+    short_comments = [c for c in comments if len(c["content"]) <= 50]
+
+    if long_comments:
+        lines.append(
+            "## Detailed Comments (high weight: reviews / opinions / discussions)"
+        )
+        lines.append("")
+        for c in long_comments:
+            lines.append(f'[{c["created"]}] On "{c["page_title"]}":')
+            lines.append(f"  {c['content']}")
+            lines.append("")
+
+    if short_comments:
+        lines.append("## Short Comments (style reference)")
+        lines.append("")
+        for c in short_comments[:100]:
+            lines.append(f"[{c['created']}] {c['content']}")
+
+    return "\n".join(lines)
+
+
+# --- Main collection flow -----------------------------------------------------
+
+
+def collect_all(
+    name: str,
+    output_dir: Path,
+    doc_limit: int,
+    comment_limit: int,
+    space_key: Optional[str],
+    config: dict,
+) -> dict:
+    """Collect all Confluence data for a colleague, output to output_dir."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    results: dict = {}
+
+    print(f"\nStarting collection: {name}\n", file=sys.stderr)
+
+    # Init client
+    try:
+        client = ConfClient(config)
+        # Quick connectivity check
+        check = client.get("/rest/api/space", params={"limit": 1})
+        if check is None:
+            raise AuthError("Cannot connect to Confluence")
+        print(f"  Connected to: {config['base_url']}", file=sys.stderr)
+    except AuthError as e:
+        print(f"Auth error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    # Step 1: Find user
+    user = find_user(name, client, config)
+    if not user:
+        print(f"User not found: {name}", file=sys.stderr)
+        sys.exit(1)
+
+    display_name = user.get("displayName", name)
+
+    pages = []
+    comments = []
+
+    # Step 2: Collect pages
+    print(f"\nCollecting pages (limit {doc_limit})...", file=sys.stderr)
+    try:
+        pages = collect_pages(user, client, doc_limit, space_key)
+        if pages:
+            doc_content = format_docs(pages, display_name)
+            doc_path = output_dir / "docs.txt"
+            doc_path.write_text(doc_content, encoding="utf-8")
+            results["docs"] = str(doc_path)
+            print(f"  Pages -> {doc_path}", file=sys.stderr)
+        else:
+            print("  No pages found", file=sys.stderr)
+    except CollectorError as e:
+        print(f"  Page collection failed: {e}", file=sys.stderr)
+    except Exception as e:
+        print(f"  Page collection error: {e}", file=sys.stderr)
+
+    # Step 3: Collect comments
+    print(f"\nCollecting comments (limit {comment_limit})...", file=sys.stderr)
+    try:
+        comments = collect_comments(user, client, comment_limit, space_key)
+        if comments:
+            comment_content = format_comments(comments, display_name)
+            comment_path = output_dir / "messages.txt"
+            comment_path.write_text(comment_content, encoding="utf-8")
+            results["comments"] = str(comment_path)
+            print(f"  Comments -> {comment_path}", file=sys.stderr)
+        else:
+            print("  No comments found", file=sys.stderr)
+    except CollectorError as e:
+        print(f"  Comment collection failed: {e}", file=sys.stderr)
+    except Exception as e:
+        print(f"  Comment collection error: {e}", file=sys.stderr)
+
+    # Write summary
+    summary = {
+        "name": display_name,
+        "username": user.get("username", ""),
+        "source": "confluence",
+        "base_url": config["base_url"],
+        "space_key": space_key,
+        "pages_collected": len(pages),
+        "comments_collected": len(comments),
+        "collected_at": datetime.now(timezone.utc).isoformat(),
+        "files": results,
+    }
+    summary_path = output_dir / "collection_summary.json"
+    summary_path.write_text(json.dumps(summary, ensure_ascii=False, indent=2))
+    print(f"  Summary -> {summary_path}", file=sys.stderr)
+
+    print(f"\nCollection complete. Output: {output_dir}", file=sys.stderr)
+    return results
+
+
+# --- CLI entry ----------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Confluence Auto-Collector",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # First-time setup
+  python3 confluence_auto_collector.py --setup
+
+  # Collect colleague data
+  python3 confluence_auto_collector.py --name "John Doe"
+  python3 confluence_auto_collector.py --name "john.doe" --output-dir ./knowledge/john --doc-limit 30
+  python3 confluence_auto_collector.py --name "John" --space-key DEV --doc-limit 20
+        """,
+    )
+    parser.add_argument("--setup", action="store_true", help="Initialize config")
+    parser.add_argument("--name", help="Colleague name or Confluence username")
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        help="Output directory (default: ./knowledge/{name})",
+    )
+    parser.add_argument(
+        "--doc-limit",
+        type=int,
+        default=DEFAULT_DOC_LIMIT,
+        help=f"Max pages to collect (default {DEFAULT_DOC_LIMIT})",
+    )
+    parser.add_argument(
+        "--comment-limit",
+        type=int,
+        default=DEFAULT_COMMENT_LIMIT,
+        help=f"Max comments to collect (default {DEFAULT_COMMENT_LIMIT})",
+    )
+    parser.add_argument(
+        "--space-key",
+        default=None,
+        help="Filter by Confluence space key (e.g. DEV, TEAM)",
+    )
+
+    args = parser.parse_args()
+
+    if args.setup:
+        setup_config()
+        return
+
+    if not args.name:
+        parser.print_help()
+        parser.error("Please provide --name")
+
+    config = load_config()
+    output_dir = (
+        Path(args.output_dir) if args.output_dir else Path(f"./knowledge/{args.name}")
+    )
+
+    try:
+        collect_all(
+            name=args.name,
+            output_dir=output_dir,
+            doc_limit=args.doc_limit,
+            comment_limit=args.comment_limit,
+            space_key=args.space_key,
+            config=config,
+        )
+    except CollectorError as e:
+        print(f"\nCollection failed: {e}", file=sys.stderr)
+        sys.exit(1)
+    except KeyboardInterrupt:
+        print("\n\nCancelled", file=sys.stderr)
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add Confluence Cloud and Server/Data Center support as a new data source for collecting colleague knowledge (pages, comments).

## Changes

### New file
- `tools/confluence_auto_collector.py` — Confluence auto-collector
  - Cloud auth (email + API Token) and Server auth (PAT / Basic)
  - User search via `/rest/api/search/user` with accountId for CQL (Cloud)
  - Page collection (creator + contributor) with optional space filtering
  - Comment collection with long/short classification
  - Rate-limit retry, HTML-to-text conversion, unified output format
  - CLI with `--setup`, `--name`, `--output-dir`, `--doc-limit`, `--comment-limit`, `--space-key`

### Modified files
- `SKILL.md` — Add Option B2 (Confluence) in both CN and EN versions, tool table, detailed usage
- `README.md` — Add Confluence to data source table, project structure, dependency note
- `INSTALL.md` — Add Confluence Cloud/Server setup guide, usage examples, troubleshooting
- `requirements.txt` — Note `requests` is also used by Confluence collector

## Testing

Verified against live Confluence Cloud instance (`tmobi.atlassian.net`):
- User search: Korean display name → accountId mapping
- Page collection: 3 pages with space filter (AIAGENTPJT)
- Comment collection: 5 comments with long/short classification
- Output files: `docs.txt`, `messages.txt`, `collection_summary.json`
- Unit tests: html_to_text, format_docs, format_comments, ConfClient auth (3 modes), error handling
