### PR TITLE
chore: add CI, issue/PR templates, and CONTRIBUTING.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report / Bug 报告
+about: Report something that is broken. / 报告出错的功能。
+title: "[Bug] "
+labels: ["bug", "needs-triage"]
+assignees: []
+---
+
+## Describe the bug / 描述 bug
+
+<!-- Clear, concise description. / 简明描述。 -->
+
+## Steps to reproduce / 复现步骤
+
+1.
+2.
+3.
+
+## Expected behavior / 期望行为
+
+## Actual behavior / 实际行为
+
+<!-- Paste error output, stack trace, or screenshots. / 贴出错误输出、堆栈或截图。 -->
+
+```
+<!-- logs here / 在这里贴日志 -->
+```
+
+## Environment / 环境
+
+- OS: <!-- e.g. macOS 14.5, Ubuntu 22.04 -->
+- Python: <!-- output of `python3 --version` -->
+- Host: <!-- Claude Code / OpenClaw / other -->
+- colleague-skill commit: <!-- output of `git rev-parse --short HEAD` -->
+- Data source: <!-- Feishu / DingTalk / Slack / Confluence / WeChat / manual -->
+
+## Additional context / 补充信息
+
+<!-- Anything else we should know? Related issues, recent changes, etc. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Discord community
+    url: https://discord.gg/aRjmJBdK
+    about: Chat, ask quick questions, and share skills. / 聊天、快速提问、分享 skill。
+  - name: 🖼️ Skill gallery
+    url: https://titanwings.github.io/colleague-skill-site/
+    about: Browse or submit a community skill. / 浏览或提交社区 skill。

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature request / 功能建议
+about: Suggest a new capability or improvement. / 提出新功能或改进建议。
+title: "[Feature] "
+labels: ["enhancement", "needs-triage"]
+assignees: []
+---
+
+## Problem / 要解决的问题
+
+<!-- What are you trying to do? What's missing today? / 你想做什么？现在缺了什么？ -->
+
+## Proposed solution / 建议方案
+
+<!-- How would you like it to work? / 你希望它怎么工作？ -->
+
+## Alternatives considered / 考虑过的其它方案
+
+<!-- Other approaches you thought about and why this one is better. / 你考虑过的其它做法，以及为什么这个更好。 -->
+
+## Would you be willing to submit a PR? / 你愿意提 PR 吗？
+
+- [ ] Yes, I can work on this / 我愿意
+- [ ] I can help test / 我可以帮忙测试
+- [ ] Just suggesting / 只是建议

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,27 @@
+---
+name: Question / 提问
+about: Ask how to use colleague.skill. / 咨询如何使用 colleague.skill。
+title: "[Question] "
+labels: ["question"]
+assignees: []
+---
+
+<!--
+Before opening a question, please check:
+提问之前请先看：
+
+- README.md / INSTALL.md / SKILL.md
+- Existing issues and discussions / 已有的 issue 和讨论
+- Discord: https://discord.gg/aRjmJBdK
+-->
+
+## What are you trying to do? / 你想做什么？
+
+## What have you tried? / 你试过什么？
+
+## Environment / 环境
+
+- OS:
+- Python:
+- Host: Claude Code / OpenClaw / other:
+- Data source:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,38 @@
+<!--
+Thanks for contributing to colleague.skill! 感谢你的贡献！
+Please fill out the sections below. 请填写下方各部分。
+-->
+
+## Summary / 摘要
+
+<!-- What does this PR do? One or two sentences. / 这个 PR 做了什么？一两句话说明。 -->
+
+## Changes / 变更
+
+<!-- Bullet list of notable changes. / 主要改动列表。 -->
+-
+-
+
+## Motivation / 动机
+
+<!-- Why is this change needed? Link related issues. / 为什么需要这个改动？关联 issue。 -->
+Closes #
+
+## Testing / 测试
+
+<!-- How did you verify this works? Commands, screenshots, or manual steps. / 你是怎么验证的？命令、截图或手动步骤。 -->
+- [ ] `python -m unittest discover -s tests -p 'test_*.py'` passed
+- [ ] `python -m compileall tools/` passed
+- [ ] Manually tested: <!-- describe -->
+
+## Checklist / 检查清单
+
+- [ ] I read [CONTRIBUTING.md](../CONTRIBUTING.md)
+- [ ] Docs updated if behavior or usage changed (README / SKILL.md / INSTALL.md)
+- [ ] No secrets, tokens, or personal data committed
+- [ ] New dependencies added to `requirements.txt` (if any)
+- [ ] Tests added/updated for new functionality (or reason explained above)
+
+## Screenshots / 截图 (optional)
+
+<!-- Drop images here if UI or output changed. / 如果有 UI 或输出变化，贴图。 -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Python ${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+      - name: Compile all Python sources
+        run: python -m compileall -q tools
+
+      - name: Run unit tests
+        run: |
+          if [ -d tests ]; then
+            python -m unittest discover -s tests -p 'test_*.py' -v
+          else
+            echo "No tests/ directory yet — skipping unittest discover."
+          fi
+
+  lint:
+    name: Ruff
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install ruff
+        run: pip install ruff
+      - name: Run ruff (non-blocking for now)
+        run: ruff check tools/ || true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,118 @@
+# Contributing to colleague.skill / 贡献指南
+
+> English first, 中文在下方。
+
+Thank you for considering a contribution! This project turns colleagues (and anyone else) into AI skills, and it's only as good as its community.
+
+感谢你愿意贡献。这个项目的目标是把同事（以及任何人）蒸馏成 AI skill，社区越活跃它就越好。
+
+---
+
+## Ways to contribute / 贡献方式
+
+- **Report bugs** — open a [bug report](.github/ISSUE_TEMPLATE/bug_report.md)
+- **Suggest features** — open a [feature request](.github/ISSUE_TEMPLATE/feature_request.md)
+- **Translate docs** — see `docs/lang/` for existing languages
+- **Add a data source collector** — e.g. `tools/slack_auto_collector.py` is a reference implementation
+- **Submit a community skill** — submit to the [gallery](https://titanwings.github.io/colleague-skill-site/)
+- **Improve prompts** — files under `prompts/` shape skill behavior; small wording tweaks are welcome
+
+---
+
+## Development setup / 开发环境
+
+```bash
+git clone https://github.com/titanwings/colleague-skill.git
+cd colleague-skill
+pip3 install -r requirements.txt
+```
+
+Python 3.9+ is required. Optional extras (`openpyxl`, auto-collector credentials) are covered in [INSTALL.md](INSTALL.md).
+
+---
+
+## Branch & PR workflow / 分支和 PR 流程
+
+1. Fork the repo and create a branch from `main`:
+   - `feat/<short-name>` for new features
+   - `fix/<short-name>` for bug fixes
+   - `docs/<short-name>` for docs only
+   - `chore/<short-name>` for tooling / infra
+2. Make your changes. Keep PRs focused — one concern per PR.
+3. Run tests and compile checks locally:
+   ```bash
+   python -m compileall tools/
+   python -m unittest discover -s tests -p 'test_*.py' -v
+   ```
+4. Open a PR against `main`. Fill out the PR template.
+5. CI must pass. A maintainer will review — please be patient, and feel free to ping on Discord if it's been a week.
+
+---
+
+## Commit message style / 提交信息规范
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add Notion auto-collector
+fix: handle 429 rate limit in feishu_parser
+docs: translate INSTALL to Korean
+chore: bump requests to 2.32
+test: cover skill_writer rollback edge cases
+```
+
+Keep the subject under 72 characters. Use the body for the *why*, not the *what*.
+
+---
+
+## Code style / 代码风格
+
+- Match surrounding code — we don't enforce a formatter yet, but consistency matters
+- Python: prefer standard library where possible; add to `requirements.txt` only if necessary
+- Tools under `tools/` should be runnable as standalone CLIs (`if __name__ == "__main__":`)
+- Prompts under `prompts/` are plain Markdown — keep them concise and task-specific
+
+---
+
+## Tests / 测试
+
+New functionality should come with tests under `tests/test_*.py`. Use `unittest` (stdlib) — no extra test framework.
+
+When adding a new data source collector, at minimum cover:
+- Auth modes (token / user+password / etc.)
+- Rate-limit / retry behavior (mock HTTP)
+- Output format consistency with existing collectors
+
+Don't hit live APIs in CI. Mock with `unittest.mock` or the `responses` library.
+
+---
+
+## Security / 安全
+
+- **Never commit secrets, tokens, or personal data.** If you accidentally do, rotate the credential immediately and let a maintainer know.
+- Config files that hold credentials should be written to the user's home (e.g. `~/.colleague-skill/`) with permission `0600`.
+- If you find a security issue, **do not open a public issue.** Email the maintainer or DM on Discord.
+
+---
+
+## Docs / 文档
+
+- User-facing behavior changes → update `README.md`, `SKILL.md`, and `INSTALL.md`
+- If you add a language translation of the README, also update the language nav strip in every other `docs/lang/README_*.md`
+- Prefer English for code comments; docs can be bilingual
+
+---
+
+## Community / 社区
+
+- [💬 Discord](https://discord.gg/aRjmJBdK) — main chat
+- [GitHub Discussions](https://github.com/titanwings/colleague-skill/discussions) — long-form Q&A and design threads
+- [Skill gallery](https://titanwings.github.io/colleague-skill-site/) — browse and submit skills
+
+Be kind. Assume good intent. Disagree on the idea, not the person.
+
+---
+
+## License / 许可
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## Summary

Set up community-facing infrastructure so future PRs (e.g. #106 Confluence collector) can be reviewed against a consistent bar.

## Changes

- **`.github/workflows/ci.yml`** — GitHub Actions CI
  - `python -m compileall tools/` — catches syntax errors in every tool
  - `python -m unittest discover -s tests -p 'test_*.py'` — no-op until a \`tests/\` directory exists, then picks up everything automatically
  - Ruff lint job (non-blocking, `|| true`) — surfaces style/quality hints without failing PRs while we adopt
  - Matrix over Python 3.9 and 3.11; triggers on push to `main` and on PRs
- **`.github/PULL_REQUEST_TEMPLATE.md`** — bilingual EN/CN template with a testing checklist, secrets reminder, and doc-update prompt
- **`.github/ISSUE_TEMPLATE/`** — bug / feature / question templates + `config.yml` that disables blank issues and links to Discord and the skill gallery
- **`CONTRIBUTING.md`** — branch naming, Conventional Commits, dev setup, test expectations, security rules (no secrets, `0600` perms on credential files), i18n expectations

## Testing

- [x] Locally compiled with `python -m compileall tools/` — passes
- [ ] CI will run on this PR — that's the real test
- [x] Templates render correctly in GitHub preview (verified via raw file structure)

## Notes for reviewer

- The `tests/` directory doesn't exist yet on `main`. The CI handles this gracefully (prints a message, doesn't fail). Once PR #103 or any future PR adds tests, discovery activates automatically.
- Ruff is intentionally non-blocking for now. Flip `|| true` to hard-fail once the codebase is clean.
- Branch protection rules (require CI pass, require 1 approval) are a separate GitHub Settings change, not in this PR.